### PR TITLE
Feature/small fixes take 2

### DIFF
--- a/asyncfix/__init__.py
+++ b/asyncfix/__init__.py
@@ -5,5 +5,5 @@ from .message import FIXMessage
 from .connection import AsyncFIXConnection, ConnectionRole, ConnectionState
 from .connection_client import AsyncFIXClient
 from .connection_server import AsyncFIXDummyServer
-from .fix_tester import FIXTester
+from .fix_tester import FIXTester, FIXConnTester
 from .journaler import Journaler

--- a/asyncfix/codec.py
+++ b/asyncfix/codec.py
@@ -1,7 +1,7 @@
 """FIX Message encoding / decoding module."""
 
 import logging
-from datetime import UTC, datetime
+from datetime import datetime, timezone
 
 from asyncfix import FMsg, FTag
 from asyncfix.errors import EncodingError, InvalidTagError
@@ -13,7 +13,11 @@ MINIMUM_MSG_LENGTH = 3
 TOKENS_LENGTH = 2
 
 
-def _split_tag(tag: str, silent: bool = True, custom_error: str = "") -> tuple[str, str]:
+def _split_tag(
+    tag: str,
+    silent: bool = True,
+    custom_error: str = "",
+) -> tuple[str, str]:
     tokens = tag.split("=", 1)
     if len(tokens) != TOKENS_LENGTH:
         if custom_error:
@@ -59,7 +63,7 @@ class Codec:
     @staticmethod
     def current_datetime() -> str:
         """FIX complaint date-time string (UTC now)."""
-        return datetime.now(UTC).strftime("%Y%m%d-%H:%M:%S.%f")[:-3]
+        return datetime.now(timezone.utc).strftime("%Y%m%d-%H:%M:%S.%f")[:-3]
 
     def _add_tag(self, body: list[str], t: str, msg: FIXContainer) -> None:
         if msg.is_group(t):

--- a/asyncfix/codec.py
+++ b/asyncfix/codec.py
@@ -124,10 +124,10 @@ class Codec:
 
         # Create header
         header = []
-        msg_type = f"{FTag.MsgType}={msg_type}"
+        msg_type_str = f"{FTag.MsgType}={msg_type}"
         header.append(f"{FTag.BeginString}={self.protocol.beginstring}")
-        header.append(f"{FTag.BodyLength}={len(body_string) + len(msg_type) + 1}")
-        header.append(msg_type)
+        header.append(f"{FTag.BodyLength}={len(body_string) + len(msg_type_str) + 1}")
+        header.append(msg_type_str)
 
         fix_msg = self.SOH.join(header) + self.SOH + body_string
         cksum = sum([ord(i) for i in fix_msg]) % 256
@@ -247,7 +247,8 @@ class Codec:
                 try:
                     decoded_msg.msg_type = FMsg(value)
                 except ValueError:
-                    decoded_msg.msg_type = value
+                    assert silent, f"Invalid msg_type {value}"
+                    return None, len(rawmsg), None
 
             # found the start of a repeating group
             if tag in repeating_group_tags:

--- a/asyncfix/codec.py
+++ b/asyncfix/codec.py
@@ -1,6 +1,7 @@
 """FIX Message encoding / decoding module."""
+
 import logging
-from datetime import datetime
+from datetime import UTC, datetime
 
 from asyncfix import FMsg, FTag
 from asyncfix.errors import EncodingError
@@ -8,9 +9,17 @@ from asyncfix.message import FIXContainer, FIXMessage, RepeatingTagError
 from asyncfix.protocol import FIXProtocolBase
 from asyncfix.session import FIXSession
 
+MINIMUM_MSG_LENGTH = 3
+TOKENS_LENGTH = 2
+
 
 class _RepeatingGroupContext(FIXContainer):
-    def __init__(self, tag, repeating_group_tags, parent):
+    def __init__(
+        self,
+        tag: str,
+        repeating_group_tags: list[str],
+        parent: FIXContainer,
+    ) -> None:
         self.tag = tag
         self.repeating_group_tags = repeating_group_tags
         self.parent = parent
@@ -23,13 +32,15 @@ class Codec:
     Attributes:
         protocol: FIX protocol
         SOH: encoded message separator
+
     """
 
-    def __init__(self, protocol: FIXProtocolBase):
+    def __init__(self, protocol: FIXProtocolBase) -> None:
         """Codec init.
 
         Args:
             protocol: FIX protocol used in encoding/decoding
+
         """
         self.protocol: FIXProtocolBase = protocol
         self.SOH = "\x01"
@@ -37,17 +48,17 @@ class Codec:
     @staticmethod
     def current_datetime() -> str:
         """FIX complaint date-time string (UTC now)."""
-        return datetime.utcnow().strftime("%Y%m%d-%H:%M:%S.%f")[:-3]
+        return datetime.now(UTC).strftime("%Y%m%d-%H:%M:%S.%f")[:-3]
 
-    def _addTag(self, body, t, msg: FIXContainer):
+    def _add_tag(self, body: list[str], t: str, msg: FIXContainer) -> None:
         if msg.is_group(t):
             groups = msg.get_group_list(t)
-            body.append("%s=%s" % (t, len(groups)))
+            body.append(f"{t}={len(groups)}")
             for group in groups:
                 for tag in group.tags:
-                    self._addTag(body, tag, group)
+                    self._add_tag(body, tag, group)
         else:
-            body.append("%s=%s" % (t, msg[t]))
+            body.append(f"{t}={msg[t]}")
 
     def encode(
         self,
@@ -67,40 +78,37 @@ class Codec:
 
         Raises:
             EncodingError: when failed MsgSeqNum conditions for some types of messages
+
         """
         # Create body
-        body = []
+        body = [
+            f"{FTag.SenderCompID}={session.sender_comp_id}",
+            f"{FTag.TargetCompID}={session.target_comp_id}",
+        ]
 
         msg_type = msg.msg_type
-
-        body.append("%s=%s" % (FTag.SenderCompID, session.sender_comp_id))
-        body.append("%s=%s" % (FTag.TargetCompID, session.target_comp_id))
-
-        seq_no = 0
         if raw_seq_num:
             seq_no = int(msg[FTag.MsgSeqNum])
+        elif msg_type == FMsg.SEQUENCERESET:
+            if FTag.MsgSeqNum not in msg:
+                raise EncodingError(
+                    "SequenceReset must have the MsgSeqNum already populated",
+                )
+            seq_no = int(msg[FTag.MsgSeqNum])
+        elif msg.get(FTag.PossDupFlag, "N") == "Y":
+            # if we have the PossDupFlag set, we need to send the message
+            # with the same seqNo
+            if FTag.MsgSeqNum not in msg:
+                raise EncodingError(
+                    "Failed to encode message with PossDupFlag=Y but no"
+                    " previous MsgSeqNum",
+                )
+            seq_no = int(msg[FTag.MsgSeqNum])
         else:
-            if msg_type == FMsg.SEQUENCERESET:
-                if FTag.MsgSeqNum not in msg:
-                    raise EncodingError(
-                        "SequenceReset must have the MsgSeqNum already populated"
-                    )
-                seq_no = int(msg[FTag.MsgSeqNum])
-            else:
-                # if we have the PossDupFlag set, we need to send the message
-                #   with the same seqNo
-                if msg.get(FTag.PossDupFlag, "N") == "Y":
-                    if FTag.MsgSeqNum not in msg:
-                        raise EncodingError(
-                            "Failed to encode message with PossDupFlag=Y but no"
-                            " previous MsgSeqNum"
-                        )
-                    seq_no = int(msg[FTag.MsgSeqNum])
-                else:
-                    seq_no = session.allocate_next_num_out()
+            seq_no = session.allocate_next_num_out()
 
-        body.append("%s=%s" % (FTag.MsgSeqNum, seq_no))
-        body.append("%s=%s" % (FTag.SendingTime, self.current_datetime()))
+        body.append(f"{FTag.MsgSeqNum}={seq_no}")
+        body.append(f"{FTag.SendingTime}={self.current_datetime()}")
 
         for t in msg.tags:
             if t in {
@@ -110,28 +118,24 @@ class Codec:
                 FTag.TargetCompID,
             }:
                 continue
-            self._addTag(body, t, msg)
+            self._add_tag(body, t, msg)
 
-        # Enable easy change when debugging
-        SEP = self.SOH
-
-        body = self.SOH.join(body) + self.SOH
+        body_string = self.SOH.join(body) + self.SOH
 
         # Create header
         header = []
-        msg_type = "%s=%s" % (FTag.MsgType, msg_type)
-        header.append("%s=%s" % (FTag.BeginString, self.protocol.beginstring))
-        header.append("%s=%i" % (FTag.BodyLength, len(body) + len(msg_type) + 1))
+        msg_type = f"{FTag.MsgType}={msg_type}"
+        header.append(f"{FTag.BeginString}={self.protocol.beginstring}")
+        header.append(f"{FTag.BodyLength}={len(body_string) + len(msg_type) + 1}")
         header.append(msg_type)
 
-        fixmsg = self.SOH.join(header) + self.SOH + body
-
-        cksum = sum([ord(i) for i in fixmsg]) % 256
-        fixmsg = fixmsg + "%s=%0.3i" % (FTag.CheckSum, cksum)
+        fix_msg = self.SOH.join(header) + self.SOH + body_string
+        cksum = sum([ord(i) for i in fix_msg]) % 256
+        fix_msg = fix_msg + f"{FTag.CheckSum}={cksum:03}"
 
         # print len(fixmsg)
 
-        return fixmsg + SEP
+        return fix_msg + self.SOH
 
     def decode(
         self,
@@ -147,6 +151,7 @@ class Codec:
         Returns:
             if OK - (FIXMessage, bytes_processed, valid_raw_msg_bytes)
             if ERR - (None, n_bytes_skip, None)
+
         """
         valid_idx = rawmsg.find(b"8=FIX.")
         if valid_idx == -1:
@@ -171,37 +176,41 @@ class Codec:
             msg = msg[:-1]
 
         # at a minimum we require BeginString, BodyLength & Checksum
-        if len(msg) < 3:
+        if len(msg) < MINIMUM_MSG_LENGTH:
             assert silent, "Minimum message"
-            return (None, parsed_length, None)
+            return None, parsed_length, None
 
         tag, value = msg[0].split("=", 1)
         if value != self.protocol.beginstring:
             logging.error(
-                "FIX Version unexpected (Recv: %s Expected: %s)"
-                % (value, self.protocol.beginstring)
+                "FIX Version unexpected (Recv: %s Expected: %s)",
+                value,
+                self.protocol.beginstring,
             )
             assert silent, "protocol beginstring mismatch"
-            return (None, len(rawmsg), None)
+            return None, len(rawmsg), None
 
-        toks = msg[1].split("=", 1)
-        if len(toks) != 2:
+        tokens = msg[1].split("=", 1)
+        if len(tokens) != TOKENS_LENGTH:
             assert silent, f"BodyLength split error {msg}"
-            return (None, len(rawmsg), None)
-        tag, value = toks
+            return None, len(rawmsg), None
+        tag, value = tokens
 
         msg_length = len(msg[0]) + len(msg[1]) + len("10=000") + 3
         if tag != FTag.BodyLength:
-            logging.error(f"*** BodyLength missing or not 2nd field *** [{tag}]: {msg}")
+            logging.error(
+                "*** BodyLength missing or not 2nd field *** [%s]: %s",
+                tag,
+                msg,
+            )
             assert silent, "2nd tag must be BodyLength"
-            return (None, len(rawmsg), None)
-        else:
-            msg_length += int(value)
+            return None, len(rawmsg), None
+        msg_length += int(value)
 
         # message looks incomplete
         if msg_length > len(rawmsg):
             assert silent, "incomplete message"
-            return (None, parsed_length, None)
+            return None, parsed_length, None
 
         checksum_passed = False
         parsed_length += msg_length
@@ -212,11 +221,11 @@ class Codec:
         current_context = decoded_msg
 
         for m in msg:
-            toks = m.split("=", 1)
-            if len(toks) != 2:
+            tokens = m.split("=", 1)
+            if len(tokens) != TOKENS_LENGTH:
                 assert silent, f"incomplete tag {m}"
-                return (None, len(rawmsg), None)
-            tag, value = toks
+                return None, len(rawmsg), None
+            tag, value = tokens
 
             if tag == FTag.CheckSum:
                 cheksum_base = self.SOH.join(msg[:-1])
@@ -224,7 +233,9 @@ class Codec:
 
                 if checksum != int(value):
                     logging.warning(
-                        "\tCheckSum: %s (INVALID) expecting %s" % (int(value), checksum)
+                        "\tCheckSum: %s (INVALID) expecting %s",
+                        int(value),
+                        checksum,
                     )
                     assert (
                         silent
@@ -247,14 +258,17 @@ class Codec:
                         and tag not in current_context.repeating_group_tags
                     ):
                         current_context.parent.add_group(
-                            current_context.tag, current_context
+                            current_context.tag,
+                            current_context,
                         )
                         current_context = current_context.parent
                         # pop the completed group off the stack
                         del repeating_groups[-1]
 
                 ctx = _RepeatingGroupContext(
-                    tag, repeating_group_tags[tag], current_context
+                    tag,
+                    repeating_group_tags[tag],
+                    current_context,
                 )
                 repeating_groups.append(ctx)
                 current_context = ctx
@@ -265,7 +279,8 @@ class Codec:
                     repeating_groups and tag not in current_context.repeating_group_tags
                 ):
                     current_context.parent.add_group(
-                        current_context.tag, current_context
+                        current_context.tag,
+                        current_context,
                     )
                     current_context = current_context.parent
                     # pop the completed group off the stack
@@ -275,7 +290,8 @@ class Codec:
                     # if the repeating group already contains this field,
                     #     start the next
                     current_context.parent.add_group(
-                        current_context.tag, current_context
+                        current_context.tag,
+                        current_context,
                     )
                     ctx = _RepeatingGroupContext(
                         current_context.tag,
@@ -288,16 +304,14 @@ class Codec:
 
                 # else add it to the current one
                 current_context.set(tag, value)
+            elif tag in decoded_msg:
+                # Repeating tag found, possibly RepGrp not in protocol schema
+                decoded_msg.set(tag, RepeatingTagError)
             else:
-                if tag in decoded_msg:
-                    # Repeating tag found, possibly RepGrp not in protocol schema
-                    decoded_msg.set(tag, RepeatingTagError)
-                else:
-                    # this isn't a repeating group field, so just add it normally
-                    decoded_msg.set(tag, value)
+                # this isn't a repeating group field, so just add it normally
+                decoded_msg.set(tag, value)
 
         if checksum_passed:
-            return (decoded_msg, parsed_length, encoded_msg)
-        else:
-            assert silent, f"Checksum probably missing: {msg}"
-            return (None, parsed_length, None)
+            return decoded_msg, parsed_length, encoded_msg
+        assert silent, f"Checksum probably missing: {msg}"
+        return None, parsed_length, None

--- a/asyncfix/codec.py
+++ b/asyncfix/codec.py
@@ -4,13 +4,24 @@ import logging
 from datetime import UTC, datetime
 
 from asyncfix import FMsg, FTag
-from asyncfix.errors import EncodingError
+from asyncfix.errors import EncodingError, InvalidTagError
 from asyncfix.message import FIXContainer, FIXMessage, RepeatingTagError
 from asyncfix.protocol import FIXProtocolBase
 from asyncfix.session import FIXSession
 
 MINIMUM_MSG_LENGTH = 3
 TOKENS_LENGTH = 2
+
+
+def _split_tag(tag: str, silent: bool = True, custom_error: str = "") -> tuple[str, str]:
+    tokens = tag.split("=", 1)
+    if len(tokens) != TOKENS_LENGTH:
+        if custom_error:
+            assert silent, f"{custom_error} {tag}"
+        else:
+            assert silent, f"incomplete tag {tag}"
+        raise InvalidTagError
+    return tokens[0], tokens[1]
 
 
 class _RepeatingGroupContext(FIXContainer):
@@ -171,16 +182,19 @@ class Codec:
 
         encoded_msg = rawmsg[valid_idx : next_msg + valid_idx]
 
-        msg = msg[:next_msg].split(self.SOH)
-        if not msg[-1]:
-            msg = msg[:-1]
+        msg_tokens = msg[:next_msg].split(self.SOH)
+        if not msg_tokens[-1]:
+            msg_tokens = msg_tokens[:-1]
 
         # at a minimum we require BeginString, BodyLength & Checksum
-        if len(msg) < MINIMUM_MSG_LENGTH:
+        if len(msg_tokens) < MINIMUM_MSG_LENGTH:
             assert silent, "Minimum message"
             return None, parsed_length, None
 
-        tag, value = msg[0].split("=", 1)
+        try:
+            tag, value = _split_tag(msg_tokens[0], silent)
+        except InvalidTagError:
+            return None, len(rawmsg), None
         if value != self.protocol.beginstring:
             logging.error(
                 "FIX Version unexpected (Recv: %s Expected: %s)",
@@ -190,23 +204,21 @@ class Codec:
             assert silent, "protocol beginstring mismatch"
             return None, len(rawmsg), None
 
-        tokens = msg[1].split("=", 1)
-        if len(tokens) != TOKENS_LENGTH:
-            assert silent, f"BodyLength split error {msg}"
+        try:
+            tag, value = _split_tag(msg_tokens[1], silent, "BodyLength split error")
+        except InvalidTagError:
             return None, len(rawmsg), None
-        tag, value = tokens
-
-        msg_length = len(msg[0]) + len(msg[1]) + len("10=000") + 3
         if tag != FTag.BodyLength:
             logging.error(
                 "*** BodyLength missing or not 2nd field *** [%s]: %s",
                 tag,
-                msg,
+                msg_tokens,
             )
             assert silent, "2nd tag must be BodyLength"
             return None, len(rawmsg), None
-        msg_length += int(value)
 
+        msg_length = len(msg_tokens[0]) + len(msg_tokens[1]) + len("10=000") + 3
+        msg_length += int(value)
         # message looks incomplete
         if msg_length > len(rawmsg):
             assert silent, "incomplete message"
@@ -216,19 +228,17 @@ class Codec:
         parsed_length += msg_length
 
         decoded_msg = FIXMessage("UNKNOWN")
-        repeating_groups = []
-        repeating_group_tags = self.protocol.repeating_groups
-        current_context = decoded_msg
+        repeating_groups: list[_RepeatingGroupContext] = []
+        current_context: FIXContainer = decoded_msg
 
-        for m in msg:
-            tokens = m.split("=", 1)
-            if len(tokens) != TOKENS_LENGTH:
-                assert silent, f"incomplete tag {m}"
+        for m in msg_tokens:
+            try:
+                tag, value = _split_tag(m, silent)
+            except InvalidTagError:
                 return None, len(rawmsg), None
-            tag, value = tokens
 
             if tag == FTag.CheckSum:
-                cheksum_base = self.SOH.join(msg[:-1])
+                cheksum_base = self.SOH.join(msg_tokens[:-1])
                 checksum = (sum([ord(i) for i in cheksum_base]) + 1) % 256
 
                 if checksum != int(value):
@@ -239,7 +249,7 @@ class Codec:
                     )
                     assert (
                         silent
-                    ), f"invalid checksum tag[10]={value} expected: {checksum} {msg=}"
+                    ), f"invalid checksum tag[10]={value} expected: {checksum} {msg_tokens=}"
                     checksum_passed = False
                 else:
                     checksum_passed = True
@@ -251,33 +261,12 @@ class Codec:
                     return None, len(rawmsg), None
 
             # found the start of a repeating group
-            if tag in repeating_group_tags:
+            if tag in self.protocol.repeating_groups:
                 # i.e. we are already in a repeating group
-                if type(current_context) is _RepeatingGroupContext:
-                    while (
-                        repeating_groups
-                        and tag not in current_context.repeating_group_tags
-                    ):
-                        current_context.parent.add_group(
-                            current_context.tag,
-                            current_context,
-                        )
-                        current_context = current_context.parent
-                        # pop the completed group off the stack
-                        del repeating_groups[-1]
-
-                ctx = _RepeatingGroupContext(
-                    tag,
-                    repeating_group_tags[tag],
-                    current_context,
-                )
-                repeating_groups.append(ctx)
-                current_context = ctx
-            elif repeating_groups:
-                # we have 1 or more repeating groups in progress
-                #    & our tag isn't the start of a group
                 while (
-                    repeating_groups and tag not in current_context.repeating_group_tags
+                    isinstance(current_context, _RepeatingGroupContext)
+                    and repeating_groups
+                    and tag not in current_context.repeating_group_tags
                 ):
                     current_context.parent.add_group(
                         current_context.tag,
@@ -287,7 +276,30 @@ class Codec:
                     # pop the completed group off the stack
                     del repeating_groups[-1]
 
-                if tag in current_context.tags:
+                ctx = _RepeatingGroupContext(
+                    tag,
+                    self.protocol.repeating_groups[tag],
+                    current_context,
+                )
+                repeating_groups.append(ctx)
+                current_context = ctx
+            elif repeating_groups:
+                # we have 1 or more repeating groups in progress
+                #    & our tag isn't the start of a group
+                while (
+                    isinstance(current_context, _RepeatingGroupContext)
+                    and repeating_groups
+                    and tag not in current_context.repeating_group_tags
+                ):
+                    current_context.parent.add_group(
+                        current_context.tag,
+                        current_context,
+                    )
+                    current_context = current_context.parent
+                    # pop the completed group off the stack
+                    del repeating_groups[-1]
+
+                if tag in current_context.tags and isinstance(current_context, _RepeatingGroupContext):
                     # if the repeating group already contains this field,
                     #     start the next
                     current_context.parent.add_group(
@@ -314,5 +326,5 @@ class Codec:
 
         if checksum_passed:
             return decoded_msg, parsed_length, encoded_msg
-        assert silent, f"Checksum probably missing: {msg}"
+        assert silent, f"Checksum probably missing: {msg_tokens}"
         return None, parsed_length, None

--- a/asyncfix/connection.py
+++ b/asyncfix/connection.py
@@ -486,7 +486,7 @@ class AsyncFIXConnection:
 
         Raises:
             FIXMessageError if critical error - no LOGOUT message has to be sent
-            FIXMessageError(err_msg) otherwise - LOGOUT message with 58=err_msg should be sent
+            FIXMessageError(err_msg) else - LOGOUT message with 58=err_msg should be sent
         """
         if msg[FTag.BeginString] != self.protocol.beginstring:
             raise FIXMessageError(
@@ -516,7 +516,7 @@ class AsyncFIXConnection:
                 _is_err = False
 
             if _is_err:
-                raise FIXMessageError (
+                raise FIXMessageError(
                     f"MsgSeqNum is too low, expected {self._session.next_num_in}, got"
                     f" {msg_seq_num}"
                 )

--- a/asyncfix/connection.py
+++ b/asyncfix/connection.py
@@ -151,13 +151,13 @@ class AsyncFIXConnection:
         self._heartbeat_period = heartbeat_period
         self._message_last_time = 0.0
         self._max_seq_num_resend = 0
-        self._test_req_id = None
+        self._test_req_id: Optional[int] = None
         self._socket_reader: Optional[asyncio.StreamReader] = None
         self._socket_writer: Optional[asyncio.StreamWriter] = None
         self._host = host
         self._port = int(port)
-        self._aio_task_socket_read = None
-        self._aio_task_heartbeat = None
+        self._aio_task_socket_read: Optional[asyncio.Task] = None
+        self._aio_task_heartbeat: Optional[asyncio.Task] = None
 
     @property
     def connection_state(self) -> ConnectionState:
@@ -178,6 +178,14 @@ class AsyncFIXConnection:
     def protocol(self) -> FIXProtocolBase:
         """Underlying FIXProtocolBase of a connection."""
         return self._codec.protocol
+
+    @property
+    def session(self) -> FIXSession:
+        return self._session
+
+    @property
+    def codec(self) -> Codec:
+        return self._codec
 
     async def connect(self):
         """Transport initialization method."""
@@ -268,6 +276,8 @@ class AsyncFIXConnection:
             f" {repr(msg.msg_type)}\n\t {msg_raw.decode()}\n"
         )
 
+        if self._socket_writer is None:
+            raise RuntimeError("Socket writer was not opened")
         self._socket_writer.write(encoded_msg)
         await self._socket_writer.drain()
 
@@ -324,7 +334,7 @@ class AsyncFIXConnection:
                     if parsed_length > 0:
                         self._msg_buffer = self._msg_buffer[parsed_length:]
 
-                    if decoded_msg is None:
+                    if decoded_msg is None or raw_msg is None:
                         break
 
                     await self._process_message(decoded_msg, raw_msg)

--- a/asyncfix/connection.py
+++ b/asyncfix/connection.py
@@ -4,10 +4,11 @@ import logging
 import sys
 import time
 from enum import Enum, IntEnum
+from typing import Optional
 
 from asyncfix import FMsg, FTag
 from asyncfix.codec import Codec
-from asyncfix.errors import FIXConnectionError
+from asyncfix.errors import FIXConnectionError, FIXMessageError
 from asyncfix.journaler import Journaler
 from asyncfix.message import FIXMessage, MessageDirection
 from asyncfix.protocol import FIXProtocolBase
@@ -133,7 +134,7 @@ class AsyncFIXConnection:
         if not logger:
             self.log: logging.Logger = logging.getLogger()
         else:
-            self.log: logging.Logger = logger
+            self.log = logger
 
         # Private attributes
         self._connection_state: ConnectionState = (
@@ -151,8 +152,8 @@ class AsyncFIXConnection:
         self._message_last_time = 0.0
         self._max_seq_num_resend = 0
         self._test_req_id = None
-        self._socket_reader: asyncio.StreamReader = None
-        self._socket_writer: asyncio.StreamWriter = None
+        self._socket_reader: Optional[asyncio.StreamReader] = None
+        self._socket_writer: Optional[asyncio.StreamWriter] = None
         self._host = host
         self._port = int(port)
         self._aio_task_socket_read = None
@@ -188,7 +189,7 @@ class AsyncFIXConnection:
     async def disconnect(
         self,
         disconn_state: ConnectionState,
-        logout_message: str = None,
+        logout_message: Optional[str] = None,
     ):
         """Disconnect session and closes the socket.
 
@@ -467,35 +468,34 @@ class AsyncFIXConnection:
             self._connection_was_active = True
         await self.on_state_change(connection_state)
 
-    def _validate_integrity(self, msg: FIXMessage) -> bool:
+    def _validate_integrity(self, msg: FIXMessage) -> None:
         """Validates incoming message critical integrity.
 
         Args:
             msg: incoming message
 
-        Returns:
-            None - if no error
-            True - if critical error (no Logout() message has to be sent)
-            "err msg" - Logout(58="err msg") should be sent
+        Raises:
+            FIXMessageError if critical error - no LOGOUT message has to be sent
+            FIXMessageError(err_msg) otherwise - LOGOUT message with 58=err_msg should be sent
         """
         if msg[FTag.BeginString] != self.protocol.beginstring:
-            return (
+            raise FIXMessageError(
                 "Protocol BeginString(8) mismatch, expected"
                 f" {self.protocol.beginstring}, got {msg[FTag.BeginString]}"
             )
         if FTag.SenderCompID not in msg or FTag.TargetCompID not in msg:
             # this will drop connection without a message
-            return True
+            raise FIXMessageError
 
         if not self._session.validate_comp_ids(
             msg[FTag.SenderCompID], msg[FTag.TargetCompID]
         ):
             # Sender/Target are reversed here
-            return "TargetCompID / SenderCompID mismatch"
+            raise FIXMessageError("TargetCompID / SenderCompID mismatch")
 
         # TODO: validate SendingTime ~~ within 2x heartbeat_period
         if FTag.MsgSeqNum not in msg:
-            return "MsgSeqNum(34) tag is missing"
+            raise FIXMessageError("MsgSeqNum(34) tag is missing")
 
         msg_seq_num = int(msg[FTag.MsgSeqNum])
         if msg_seq_num < self._session.next_num_in:
@@ -506,13 +506,10 @@ class AsyncFIXConnection:
                 _is_err = False
 
             if _is_err:
-                return (
+                raise FIXMessageError (
                     f"MsgSeqNum is too low, expected {self._session.next_num_in}, got"
                     f" {msg_seq_num}"
                 )
-
-        # All good
-        return None
 
     async def _process_logon(self, logon_msg: FIXMessage):
         """Processes Logon(35=A) message."""
@@ -621,6 +618,8 @@ class AsyncFIXConnection:
 
         for enc_msg in journal_replay_msgs:
             replay_msg, _, _ = self._codec.decode(enc_msg, silent=False)
+            if replay_msg is None:
+                continue
             msg_seq_num = int(replay_msg[FTag.MsgSeqNum])
 
             is_sess_msg = replay_msg[FTag.MsgType] in noreply_msgs
@@ -776,12 +775,13 @@ class AsyncFIXConnection:
             f" ({self._connection_state.name}) {repr(msg.msg_type)}\n\t {msg}\n"
         )
 
-        err_msg = self._validate_integrity(msg)
-        if err_msg:
+        try:
+            self._validate_integrity(msg)
+        except FIXMessageError as exc:
             # Some mandatory tags are missing or corrupt message
             await self.disconnect(
                 ConnectionState.DISCONNECTED_BROKEN_CONN,
-                logout_message=err_msg if isinstance(err_msg, str) else None,
+                logout_message=str(exc) if str(exc) else None,
             )
             return
         is_valid_msg_num = False

--- a/asyncfix/errors.py
+++ b/asyncfix/errors.py
@@ -33,5 +33,9 @@ class RepeatingTagError(FIXMessageError):
     """Tag was repeated after decoding, indicates mishandled fix group."""
 
 
+class InvalidTagError(FIXMessageError):
+    """Not enough tokens in tag"""
+
+
 class UnmappedRepeatedGrpError(FIXMessageError):
     """Repeating group improperly set up by protocol."""

--- a/asyncfix/fix_tester.py
+++ b/asyncfix/fix_tester.py
@@ -206,9 +206,9 @@ class FIXTester:
 
         return decoded_msg
 
-    def _next_order_id(self) -> int:
+    def _next_order_id(self) -> str:
         self._order_id += 1
-        return self._order_id
+        return str(self._order_id)
 
     def _next_exec_id(self) -> int:
         self._exec_id += 1
@@ -331,10 +331,7 @@ class FIXTester:
         assert clord_id
         m[FTag.ClOrdID] = clord_id
 
-        if order.order_id is None:
-            order_id = self._next_order_id()
-        else:
-            order_id = order.order_id
+        order_id = order.order_id or self._next_order_id()
 
         m[FTag.OrderID] = order_id
         m[FTag.ExecID] = self._next_exec_id()

--- a/asyncfix/fix_tester.py
+++ b/asyncfix/fix_tester.py
@@ -1,6 +1,6 @@
 """FIX Protocol Unit Tester."""
 from math import isnan, nan
-from typing import Optional
+from typing import Awaitable, Optional
 from unittest.mock import AsyncMock, MagicMock
 
 from asyncfix import FIXMessage, FMsg, FTag
@@ -17,8 +17,6 @@ class FIXTester:
     Attributes:
         registered_orders: registered orders (sent via FIXTester)
         schema: fix schema for validation (optional)
-        conn_init: fix connection initiator
-        conn_accept: fix virtual acceptor (simulated by FIXTester)
         initiator_sent: messages sent by initiator
         acceptor_rcv_que: raw messages received by (simulated acceptor)
         acceptor_sent: FIXMessages sent by simulated acceptor
@@ -27,20 +25,16 @@ class FIXTester:
     def __init__(
         self,
         schema: FIXSchema | None = None,
-        connection: AsyncFIXConnection | None = None,
     ):
         """Initialize FIXTester.
 
         Args:
             schema: (optional) FIXSchema for validating incoming/outgoing messages
-            connection: (optional) fix initiator connection
         """
         self.registered_orders: dict[str, FIXNewOrderSingle] = {}
         self.schema = schema
         self._order_id = 0
         self._exec_id = 10000
-        self.conn_init = connection
-        self.conn_accept = None
         self.initiator_sent: list[FIXMessage] = []
         """List of fix messages sent by self.connection.send_msg()."""
 
@@ -48,60 +42,6 @@ class FIXTester:
 
         self.acceptor_sent: list[FIXMessage] = []
         """List of fix messages sent by FIXTester.reply()."""
-
-        if self.conn_init is not None:
-            assert isinstance(connection, AsyncFIXConnection)
-            # target and session swapped! Because we mimic the server
-            j = Journaler()
-            self.conn_accept = AsyncFIXConnection(
-                FIXProtocol44(),
-                target_comp_id=self.conn_init._session.sender_comp_id,
-                sender_comp_id=self.conn_init._session.target_comp_id,
-                journaler=j,
-                host="localhost",
-                port=64444,
-                heartbeat_period=30,
-                logger=self.conn_init.log,
-            )
-            self.conn_accept._connection_state = (
-                ConnectionState.NETWORK_CONN_ESTABLISHED
-            )
-            self.conn_accept._session.next_num_out = connection._session.next_num_in
-            self.conn_accept._session.next_num_in = connection._session.next_num_out
-
-            connection._socket_writer = MagicMock()
-            connection._socket_writer.write.side_effect = (
-                self._conn_socket_write_initiator
-            )
-            connection._socket_writer.drain = AsyncMock()
-            connection._socket_writer.wait_closed = AsyncMock()
-
-            self.conn_accept._socket_writer = MagicMock()
-            self.conn_accept._socket_writer.write.side_effect = (
-                self._conn_socket_write_acceptor
-            )
-            self.conn_accept._socket_writer.drain = AsyncMock()
-            self.conn_accept._socket_writer.drain.side_effect = (
-                self._conn_socket_drain_acceptor
-            )
-            self._socket_drain_in_coro = None
-            self.conn_accept._socket_writer.wait_closed = AsyncMock()
-
-    def set_next_num(self, num_in=None, num_out=None):
-        """Set expected session seq nums for simulated acceptor.
-
-        Args:
-            num_in: next num in expected by simulated acceptor
-            num_out: next num out sent by simulated acceptor
-        """
-        if num_in is not None:
-            assert isinstance(num_in, int)
-            assert num_in > 0
-            self.conn_accept._session.next_num_in = num_in
-        if num_out is not None:
-            assert isinstance(num_out, int)
-            assert num_out > 0
-            self.conn_accept._session.next_num_out = num_out
 
     def reset_messages(self):
         """Reset messages queues of initiator and acceptor."""
@@ -140,71 +80,6 @@ class FIXTester:
             dict {FTag.MsgSeqNum: "34", "12382": "some value"}
         """
         return self.initiator_sent[index].query(*tags)
-
-    def _conn_socket_write_initiator(self, data):
-        msg, _, _ = self.conn_init._codec.decode(data, silent=False)
-        if self.schema:
-            self.schema.validate(msg)
-        self.initiator_sent.append(msg)
-        self.acceptor_rcv_que.append((msg, data))
-
-    def _conn_socket_write_acceptor(self, data):
-        msg, _, _ = self.conn_accept._codec.decode(data, silent=False)
-        if self.schema:
-            self.schema.validate(msg)
-        self.acceptor_sent.append(msg)
-
-        self._socket_drain_in_coro = self.conn_init._process_message(msg, data)
-
-    async def _conn_socket_drain_acceptor(self):
-        try:
-            if self._socket_drain_in_coro:
-                await self._socket_drain_in_coro
-        finally:
-            self._socket_drain_in_coro = None
-
-    async def process_msg_acceptor(self, index=None):
-        """Processes messages queued by initiator.send_msg().
-
-        Args:
-            index: None - processes all messages in que, number - only one at that index
-        """
-        assert self.acceptor_rcv_que, "No messages in self.acceptor_rcv_que"
-
-        while self.acceptor_rcv_que:
-            (msg, raw) = self.acceptor_rcv_que.pop(0 if index is None else index)
-            await self.conn_accept._process_message(msg, raw)
-            if index is not None:
-                break
-
-    async def reply(self, msg: FIXMessage):
-        """Manually reply to the initiator with arbitrary FIXMessage.
-
-        Args:
-            msg: arbitrary FIXMessage
-        """
-        assert self.conn_accept is not None
-        assert self.conn_init is not None
-
-        if self.schema:
-            self.schema.validate(msg)
-
-        raw_msg = self.conn_accept._codec.encode(
-            msg,
-            self.conn_accept._session,
-            raw_seq_num=FTag.MsgSeqNum in msg,
-        ).encode()
-
-        # Pretend the message was transfered to initiator
-        decoded_msg, _, _ = self.conn_init._codec.decode(raw_msg, silent=False)
-
-        if decoded_msg is not None:
-            if self.schema and decoded_msg is not None:
-                self.schema.validate(decoded_msg)
-            self.acceptor_sent.append(decoded_msg)
-            await self.conn_init._process_message(decoded_msg, raw_msg)
-
-        return decoded_msg
 
     def _next_order_id(self) -> str:
         self._order_id += 1
@@ -512,3 +387,144 @@ class FIXTester:
         if self.schema:
             self.schema.validate(msg)
         return msg
+
+
+class FIXConnTester(FIXTester):
+    """FIX protocol tester with connection.
+
+        Attributes:
+            conn_init: fix connection initiator
+            conn_accept: fix virtual acceptor (simulated by FIXTester)
+    """
+    def __init__(
+        self,
+        connection: AsyncFIXConnection,
+        schema: FIXSchema | None = None,
+    ):
+        """Initialize FIXTester.
+
+        Args:
+            schema: (optional) FIXSchema for validating incoming/outgoing messages
+            connection: (optional) fix initiator connection
+        """
+        super().__init__(schema=schema)
+
+        # target and session swapped! Because we mimic the server
+        self.conn_init = connection
+        j = Journaler()
+        self.conn_accept = AsyncFIXConnection(
+            FIXProtocol44(),
+            target_comp_id=self.conn_init.session.sender_comp_id,
+            sender_comp_id=self.conn_init.session.target_comp_id,
+            journaler=j,
+            host="localhost",
+            port=64444,
+            heartbeat_period=30,
+            logger=self.conn_init.log,
+        )
+        self.conn_accept._connection_state = (
+            ConnectionState.NETWORK_CONN_ESTABLISHED
+        )
+        self.conn_accept.session.next_num_out = connection.session.next_num_in
+        self.conn_accept.session.next_num_in = connection.session.next_num_out
+
+        connection._socket_writer = MagicMock()
+        connection._socket_writer.write.side_effect = (
+            self._conn_socket_write_initiator
+        )
+        connection._socket_writer.drain = AsyncMock()
+        connection._socket_writer.wait_closed = AsyncMock()
+
+        self.conn_accept._socket_writer = MagicMock()
+        self.conn_accept._socket_writer.write.side_effect = (
+            self._conn_socket_write_acceptor
+        )
+        self.conn_accept._socket_writer.drain = AsyncMock()
+        self.conn_accept._socket_writer.drain.side_effect = (
+            self._conn_socket_drain_acceptor
+        )
+        self._socket_drain_in_coro: Optional[Awaitable] = None
+        self.conn_accept._socket_writer.wait_closed = AsyncMock()
+
+    def set_next_num(self, num_in=None, num_out=None):
+        """Set expected session seq nums for simulated acceptor.
+
+        Args:
+            num_in: next num in expected by simulated acceptor
+            num_out: next num out sent by simulated acceptor
+        """
+        if num_in is not None:
+            assert isinstance(num_in, int)
+            assert num_in > 0
+            self.conn_accept.session.next_num_in = num_in
+        if num_out is not None:
+            assert isinstance(num_out, int)
+            assert num_out > 0
+            self.conn_accept.session.next_num_out = num_out
+
+    def _conn_socket_write_initiator(self, data):
+        msg, _, _ = self.conn_init.codec.decode(data, silent=False)
+        assert msg is not None
+        if self.schema is not None:
+            self.schema.validate(msg)
+        self.initiator_sent.append(msg)
+        self.acceptor_rcv_que.append((msg, data))
+
+    def _conn_socket_write_acceptor(self, data):
+        msg, _, _ = self.conn_accept.codec.decode(data, silent=False)
+        assert msg is not None
+        if self.schema:
+            self.schema.validate(msg)
+        self.acceptor_sent.append(msg)
+
+        self._socket_drain_in_coro = self.conn_init._process_message(msg, data)
+
+    async def _conn_socket_drain_acceptor(self):
+        try:
+            if self._socket_drain_in_coro is not None:
+                await self._socket_drain_in_coro
+        finally:
+            self._socket_drain_in_coro = None
+
+    async def process_msg_acceptor(self, index=None):
+        """Processes messages queued by initiator.send_msg().
+
+        Args:
+            index: None - processes all messages in que, number - only one at that index
+        """
+        assert self.acceptor_rcv_que, "No messages in self.acceptor_rcv_que"
+
+        while self.acceptor_rcv_que:
+            (msg, raw) = self.acceptor_rcv_que.pop(0 if index is None else index)
+            await self.conn_accept._process_message(msg, raw)
+            if index is not None:
+                break
+
+    async def reply(self, msg: FIXMessage):
+        """Manually reply to the initiator with arbitrary FIXMessage.
+
+        Args:
+            msg: arbitrary FIXMessage
+        """
+        assert self.conn_accept is not None
+        assert self.conn_init is not None
+
+        if self.schema:
+            self.schema.validate(msg)
+
+        raw_msg = self.conn_accept.codec.encode(
+            msg,
+            self.conn_accept.session,
+            raw_seq_num=FTag.MsgSeqNum in msg,
+        ).encode()
+
+        # Pretend the message was transferred to initiator
+        decoded_msg, _, _ = self.conn_init.codec.decode(raw_msg, silent=False)
+
+        if decoded_msg is not None:
+            if self.schema and decoded_msg is not None:
+                self.schema.validate(decoded_msg)
+            self.acceptor_sent.append(decoded_msg)
+            await self.conn_init._process_message(decoded_msg, raw_msg)
+
+        return decoded_msg

--- a/asyncfix/fix_tester.py
+++ b/asyncfix/fix_tester.py
@@ -1,5 +1,6 @@
 """FIX Protocol Unit Tester."""
 from math import isnan, nan
+from typing import Optional
 from unittest.mock import AsyncMock, MagicMock
 
 from asyncfix import FIXMessage, FMsg, FTag
@@ -34,7 +35,7 @@ class FIXTester:
             schema: (optional) FIXSchema for validating incoming/outgoing messages
             connection: (optional) fix initiator connection
         """
-        self.registered_orders = {}
+        self.registered_orders: dict[str, FIXNewOrderSingle] = {}
         self.schema = schema
         self._order_id = 0
         self._exec_id = 10000
@@ -43,12 +44,12 @@ class FIXTester:
         self.initiator_sent: list[FIXMessage] = []
         """List of fix messages sent by self.connection.send_msg()."""
 
-        self.acceptor_rcv_que: list[tuple(FIXMessage, bytes)] = []
+        self.acceptor_rcv_que: list[tuple[FIXMessage, bytes]] = []
 
         self.acceptor_sent: list[FIXMessage] = []
         """List of fix messages sent by FIXTester.reply()."""
 
-        if connection:
+        if self.conn_init is not None:
             assert isinstance(connection, AsyncFIXConnection)
             # target and session swapped! Because we mimic the server
             j = Journaler()
@@ -58,7 +59,7 @@ class FIXTester:
                 sender_comp_id=self.conn_init._session.target_comp_id,
                 journaler=j,
                 host="localhost",
-                port="64444",
+                port=64444,
                 heartbeat_period=30,
                 logger=self.conn_init.log,
             )
@@ -110,7 +111,7 @@ class FIXTester:
 
     def acceptor_sent_query(
         self,
-        tags: tuple[FTag | str | int] | None = None,
+        tags: tuple[FTag | str | int, ...],
         index: int = -1,
     ) -> dict[FTag | str, str]:
         """Query message sent from FIXTester to initiator.
@@ -126,7 +127,7 @@ class FIXTester:
 
     def initiator_sent_query(
         self,
-        tags: tuple[FTag | str | int] | None = None,
+        tags: tuple[FTag | str | int, ...],
         index: int = -1,
     ) -> dict[FTag | str, str]:
         """Query message sent from initiator to FixTester.
@@ -182,6 +183,9 @@ class FIXTester:
         Args:
             msg: arbitrary FIXMessage
         """
+        assert self.conn_accept is not None
+        assert self.conn_init is not None
+
         if self.schema:
             self.schema.validate(msg)
 
@@ -194,12 +198,11 @@ class FIXTester:
         # Pretend the message was transfered to initiator
         decoded_msg, _, _ = self.conn_init._codec.decode(raw_msg, silent=False)
 
-        if self.schema:
-            self.schema.validate(decoded_msg)
-
-        self.acceptor_sent.append(decoded_msg)
-
-        await self.conn_init._process_message(decoded_msg, raw_msg)
+        if decoded_msg is not None:
+            if self.schema and decoded_msg is not None:
+                self.schema.validate(decoded_msg)
+            self.acceptor_sent.append(decoded_msg)
+            await self.conn_init._process_message(decoded_msg, raw_msg)
 
         return decoded_msg
 
@@ -301,7 +304,7 @@ class FIXTester:
         last_qty: float = nan,
         price: float = nan,
         order_qty: float = nan,
-        orig_clord_id: str = None,
+        orig_clord_id: Optional[str] = None,
         avg_price: float = 0.0,
     ) -> FIXMessage:
         """Generates synthetic EXECUTIONREPORT.

--- a/asyncfix/journaler.py
+++ b/asyncfix/journaler.py
@@ -110,7 +110,7 @@ class Journaler:
             i_end = msg.index(b"\x01", i_start + 1)
             return int(msg[i_start + 4 : i_end])
         except Exception:
-            raise FIXMessageError(f"tag 34 is not found or invalid, in message: {msg}")
+            raise FIXMessageError(f"tag 34 is not found or invalid, in message: {msg.decode(encoding="utf-8")}")
 
     def set_seq_num(
         self,
@@ -129,12 +129,14 @@ class Journaler:
             assert next_num_out > 0
             session.next_num_out = next_num_out
         else:
+            assert session.next_num_out is not None and session.next_num_out > 0
             next_num_out = session.next_num_out
 
         if next_num_in is not None:
             assert next_num_in > 0
             session.next_num_in = next_num_in
         else:
+            assert session.next_num_in is not None and session.next_num_in > 0
             next_num_in = session.next_num_in
 
         self.cursor.execute(
@@ -194,7 +196,7 @@ class Journaler:
         session: FIXSession,
         direction: MessageDirection,
         seq_no: int,
-    ) -> bytes:
+    ) -> bytes | None:
         """Loads specific message from DB by seq no.
 
         Args:

--- a/asyncfix/journaler.py
+++ b/asyncfix/journaler.py
@@ -129,14 +129,14 @@ class Journaler:
             assert next_num_out > 0
             session.next_num_out = next_num_out
         else:
-            assert session.next_num_out is not None and session.next_num_out > 0
+            assert session.next_num_out > 0
             next_num_out = session.next_num_out
 
         if next_num_in is not None:
             assert next_num_in > 0
             session.next_num_in = next_num_in
         else:
-            assert session.next_num_in is not None and session.next_num_in > 0
+            assert session.next_num_in > 0
             next_num_in = session.next_num_in
 
         self.cursor.execute(

--- a/asyncfix/journaler.py
+++ b/asyncfix/journaler.py
@@ -110,7 +110,7 @@ class Journaler:
             i_end = msg.index(b"\x01", i_start + 1)
             return int(msg[i_start + 4 : i_end])
         except Exception:
-            raise FIXMessageError(f"tag 34 is not found or invalid, in message: {msg.decode(encoding="utf-8")}")
+            raise FIXMessageError(f"tag 34 is not found or invalid, in message: {msg.decode(encoding='utf-8')}")
 
     def set_seq_num(
         self,

--- a/asyncfix/message.py
+++ b/asyncfix/message.py
@@ -402,16 +402,16 @@ class FIXMessage(FIXContainer):
             msg_type: message type, must comply with FIXTag=35
             tags: initial tags values
         """
-        self._msg_type = msg_type
+        self._msg_type = msg_type if isinstance(msg_type, FMsg) else FMsg(msg_type)
         super().__init__(tags)
 
     @property
-    def msg_type(self) -> str | FMsg:
+    def msg_type(self) -> FMsg:
         """Message type."""
         return self._msg_type
 
     @msg_type.setter
-    def msg_type(self, msg_type: str | FMsg):
+    def msg_type(self, msg_type: FMsg):
         """Message type setter.
 
         Args:

--- a/asyncfix/message.py
+++ b/asyncfix/message.py
@@ -325,15 +325,15 @@ class FIXContainer:
         """Checks if container contains tags."""
         return str(item) in self.tags
 
-    def __str__(self):
+    def __str__(self) -> str:
         """As string."""
         r = ""
-        allTags = []
+        all_tags = []
         for tag, tag_value in self.tags.items():
             if _isclass(tag_value) and issubclass(tag_value, Exception):
                 tag_value = "#err#"
-            allTags.append("%s=%s" % (tag, tag_value))
-        r += "|".join(allTags)
+            all_tags.append("%s=%s" % (tag, tag_value))
+        r += "|".join(all_tags)
         return r
 
     def __eq__(self, other: object) -> bool:
@@ -419,6 +419,6 @@ class FIXMessage(FIXContainer):
         """
         self._msg_type = msg_type
 
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Repr."""
         return f"msg_type={self.msg_type}|" + super().__str__()

--- a/asyncfix/message.py
+++ b/asyncfix/message.py
@@ -1,9 +1,10 @@
 """FIX message and containers module."""
 from __future__ import annotations
 
+import inspect
 from collections import OrderedDict
 from enum import Enum
-from typing import Optional
+from typing import cast, Optional
 
 from asyncfix import FMsg, FTag
 from asyncfix.errors import (
@@ -13,13 +14,6 @@ from asyncfix.errors import (
     TagNotFoundError,
     UnmappedRepeatedGrpError,
 )
-
-
-def _isclass(cl):
-    try:
-        return issubclass(cl, cl)
-    except TypeError:
-        return False
 
 
 class MessageDirection(Enum):
@@ -55,7 +49,7 @@ class FIXContainer:
     def __init__(
         self,
         tags: Optional[dict[str | int, str | float | int | list[dict | FIXContainer]]] = None,
-    ):
+    ) -> None:
         """Initialize.
 
         Examples:
@@ -68,7 +62,7 @@ class FIXContainer:
         Args:
             tags: add tags at initialization time (all keys / values converted to str!)
         """
-        self.tags: dict[str, str | _FIXRepeatingGroupContainer] = OrderedDict()
+        self.tags: dict[str, str | _FIXRepeatingGroupContainer | type[FIXMessageError]] = OrderedDict()
 
         if tags:
             for t, v in tags.items():
@@ -77,7 +71,7 @@ class FIXContainer:
                 else:
                     self.set(t, v)
 
-    def set(self, tag: str | int, value, replace: bool = False):
+    def set(self, tag: str | int, value, replace: bool = False) -> None:
         """Set tag value.
 
         Args:
@@ -97,7 +91,7 @@ class FIXContainer:
 
         t = str(tag)
 
-        if _isclass(value):
+        if inspect.isclass(value):
             # Case for setting tags as errors (allow overwriting by Exception)
             value = value
         else:
@@ -157,7 +151,7 @@ class FIXContainer:
         else:
             return None
 
-    def add_group(self, tag: str | int, group: FIXContainer | dict, index: int = -1):
+    def add_group(self, tag: str | int, group: FIXContainer | dict, index: int = -1) -> None:
         """Add repeating group item to fix message.
 
         Args:
@@ -177,13 +171,15 @@ class FIXContainer:
 
         if tag in self:
             group_container = self.tags[tag]
+            if not isinstance(group_container, _FIXRepeatingGroupContainer):
+                raise FIXMessageError(f"Expected a repeating group container in tag {tag}")
             group_container.add_group(group, index)
         else:
             group_container = _FIXRepeatingGroupContainer()
             group_container.add_group(group, index)
             self.tags[tag] = group_container
 
-    def set_group(self, tag: str | int, groups: list[dict | FIXContainer]):
+    def set_group(self, tag: str | int, groups: list[dict | FIXContainer]) -> None:
         """Set repeating groups of the message.
 
         Args:
@@ -234,7 +230,7 @@ class FIXContainer:
                 "tag exists, but it does not belong to any group, not a group tag or"
                 " missing `repeating_group` in protocol class"
             )
-        return self.tags[tag].groups
+        return cast(_FIXRepeatingGroupContainer, self.tags[tag]).groups
 
     def get_group_by_tag(
         self,
@@ -313,24 +309,24 @@ class FIXContainer:
         """Item getter by tag."""
         return self.get(tag)
 
-    def __setitem__(self, tag: str | int, value):
+    def __setitem__(self, tag: str | int, value) -> None:
         """Item setter by tag."""
         self.set(tag, value)
 
-    def __delitem__(self, tag: str | int):
+    def __delitem__(self, tag: str | int) -> None:
         """Deletes tag from message."""
         del self.tags[str(tag)]
 
-    def __contains__(self, item: str | int):
+    def __contains__(self, item: str | int) -> bool:
         """Checks if container contains tags."""
         return str(item) in self.tags
 
-    def __str__(self) -> str:
+    def __repr__(self) -> str:
         """As string."""
         r = ""
         all_tags = []
         for tag, tag_value in self.tags.items():
-            if _isclass(tag_value) and issubclass(tag_value, Exception):
+            if inspect.isclass(tag_value) and issubclass(tag_value, Exception):
                 tag_value = "#err#"
             all_tags.append("%s=%s" % (tag, tag_value))
         r += "|".join(all_tags)
@@ -385,8 +381,6 @@ class FIXContainer:
         else:
             return False
 
-    __repr__ = __str__
-
 
 class FIXMessage(FIXContainer):
     """Generic FIXMessage."""
@@ -395,7 +389,7 @@ class FIXMessage(FIXContainer):
         self,
         msg_type: str | FMsg,
         tags: Optional[dict[str | int, str | float | int | list[dict | FIXContainer]]] = None,
-    ):
+    ) -> None:
         """Initialize.
 
         Args:
@@ -411,7 +405,7 @@ class FIXMessage(FIXContainer):
         return self._msg_type
 
     @msg_type.setter
-    def msg_type(self, msg_type: FMsg):
+    def msg_type(self, msg_type: FMsg) -> None:
         """Message type setter.
 
         Args:
@@ -419,6 +413,9 @@ class FIXMessage(FIXContainer):
         """
         self._msg_type = msg_type
 
+    def __str__(self) -> str:
+        return super().__repr__()
+
     def __repr__(self) -> str:
         """Repr."""
-        return f"msg_type={self.msg_type}|" + super().__str__()
+        return f"msg_type={self.msg_type}|" + super().__repr__()

--- a/asyncfix/message.py
+++ b/asyncfix/message.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 
 from collections import OrderedDict
 from enum import Enum
+from typing import Optional
 
 from asyncfix import FMsg, FTag
 from asyncfix.errors import (
@@ -29,16 +30,16 @@ class MessageDirection(Enum):
 
 
 class _FIXRepeatingGroupContainer:
-    def __init__(self):
+    def __init__(self) -> None:
         self.groups: list[FIXContainer] = []
 
-    def add_group(self, group, index):
+    def add_group(self, group, index) -> None:
         if index == -1:
             self.groups.append(group)
         else:
             self.groups.insert(index, group)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return str(len(self.groups)) + "=>" + str(self.groups)
 
     __repr__ = __str__
@@ -53,7 +54,7 @@ class FIXContainer:
 
     def __init__(
         self,
-        tags: dict[str | int, [str, float, int, list[dict | FIXContainer]]] = None,
+        tags: Optional[dict[str | int, str | float | int | list[dict | FIXContainer]]] = None,
     ):
         """Initialize.
 
@@ -182,7 +183,7 @@ class FIXContainer:
             group_container.add_group(group, index)
             self.tags[tag] = group_container
 
-    def set_group(self, tag: str | int, groups: list[dict, FIXContainer]):
+    def set_group(self, tag: str | int, groups: list[dict | FIXContainer]):
         """Set repeating groups of the message.
 
         Args:
@@ -282,7 +283,7 @@ class FIXContainer:
 
         return g[index]
 
-    def query(self, *tags: tuple[FTag | str | int]) -> dict[FTag | str, str]:
+    def query(self, *tags: FTag | str | int) -> dict[FTag | str, str]:
         """Request multiple tags from FIXMessage as dictionary.
 
         Args:
@@ -293,7 +294,7 @@ class FIXContainer:
         """
         result = {}
         if not tags:
-            tags = self.tags
+            tags = tuple(self.tags.keys())
 
         for t in tags:
             try:
@@ -335,7 +336,7 @@ class FIXContainer:
         r += "|".join(allTags)
         return r
 
-    def __eq__(self, other: FIXContainer | dict) -> bool:
+    def __eq__(self, other: object) -> bool:
         """Equality checks.
 
         Args:
@@ -393,7 +394,7 @@ class FIXMessage(FIXContainer):
     def __init__(
         self,
         msg_type: str | FMsg,
-        tags: dict[str | int, [str, float, int]] = None,
+        tags: Optional[dict[str | int, str | float | int | list[dict | FIXContainer]]] = None,
     ):
         """Initialize.
 

--- a/asyncfix/msgtype.py
+++ b/asyncfix/msgtype.py
@@ -25,6 +25,7 @@ class FMsg(enum.Enum, metaclass=_MsgTypeEnumMeta):
         """Hash by value."""
         return hash(self.value)
 
+    UNKNOWN = "UNKNOWN"
     HEARTBEAT = "0"
     TESTREQUEST = "1"
     RESENDREQUEST = "2"

--- a/asyncfix/protocol/order_single.py
+++ b/asyncfix/protocol/order_single.py
@@ -60,7 +60,7 @@ class FIXNewOrderSingle:
 
         self.clord_id = clord_id
         self.orig_clord_id: Optional[str] = None
-        self.order_id = None
+        self.order_id: Optional[str] = None
         self.ticker = cl_ticker
         self.side = side
         self.price = price
@@ -288,7 +288,7 @@ class FIXNewOrderSingle:
         order_status = m[FTag.OrdStatus]
 
         new_status = self.change_status(
-            self.status, m.msg_type, 0, order_status, raise_on_err=False
+            self.status, m.msg_type, FExecType.NEW, FOrdStatus(order_status), raise_on_err=False
         )
         #
         if order_status == FOrdStatus.REJECTED:
@@ -322,7 +322,7 @@ class FIXNewOrderSingle:
         leaves_qty = float(m[FTag.LeavesQty])
 
         new_status = FIXNewOrderSingle.change_status(
-            self.status, m.msg_type, exec_type, order_status, raise_on_err=False
+            self.status, m.msg_type, FExecType(exec_type), FOrdStatus(order_status), raise_on_err=False
         )
 
         self.order_id = m[FTag.OrderID]
@@ -366,7 +366,7 @@ class FIXNewOrderSingle:
             FIXNewOrderSingle.change_status(
                 self.status,
                 FMsg.ORDERCANCELREQUEST,
-                0,  # Exec Type - omitted!
+                FExecType.NEW,  # Exec Type - omitted!
                 FOrdStatus.PENDING_CANCEL,
                 raise_on_err=False,
             )
@@ -379,7 +379,7 @@ class FIXNewOrderSingle:
             FIXNewOrderSingle.change_status(
                 self.status,
                 FMsg.ORDERCANCELREPLACEREQUEST,
-                0,  # Exec Type - omitted!
+                FExecType.NEW,  # Exec Type - omitted!
                 FOrdStatus.PENDING_REPLACE,
                 raise_on_err=False,
             )

--- a/asyncfix/protocol/order_single.py
+++ b/asyncfix/protocol/order_single.py
@@ -188,7 +188,7 @@ class FIXNewOrderSingle:
         if price == self.price and qty == self.qty:
             raise FIXError("no price / qty change in replace_req")
 
-        assert not self.orig_clord_id
+        assert self.orig_clord_id is None
         self.orig_clord_id = self.clord_id
         self.clord_id = self.clord_next()
 

--- a/asyncfix/protocol/order_single.py
+++ b/asyncfix/protocol/order_single.py
@@ -2,9 +2,11 @@
 import re
 from datetime import datetime
 from math import isfinite, nan
+from typing import Optional
 
 from asyncfix import FIXMessage, FMsg, FTag
 from asyncfix.errors import FIXError
+from asyncfix.protocol.transition import get_status_transitions
 
 from .common import FExecType, FOrdSide, FOrdStatus, FOrdType
 
@@ -57,7 +59,7 @@ class FIXNewOrderSingle:
         assert clord_id, "empty clord_id"
 
         self.clord_id = clord_id
-        self.orig_clord_id = None
+        self.orig_clord_id: Optional[str] = None
         self.order_id = None
         self.ticker = cl_ticker
         self.side = side
@@ -255,125 +257,12 @@ class FIXNewOrderSingle:
                 'G' -  Order replace request (if possible to replace current order)
         :param msg_exec_type: (only for execution report), for other should be 0
         :param msg_status: new fix msg order status, or required status
+        :param raise_on_err: raise/swallow exception
         :return: FOrdStatus if state transition is possible,
                  None - if transition is valid, but need to wait for a good state
                  raises FIXError - when transition is invalid
         """
-        status_transitions = {}
-
-        if fix_msg_type == FMsg.EXECUTIONREPORT:
-            status_transitions = {
-                None: {None: FIXError},
-                # key {initial status}: {
-                #    msg_status: <transition>,
-                #       <transition>: None - ignore, True - transit, FIXError - raise
-                #
-                #      REJECTED: True,     #  this is allowed status transition
-                #      PENDING_NEW: None,  #  transition allowed but no status change
-                #      CREATED: FIXError,  #  error transition
-                #      None:  [None, True, FIXError] # default transition
-                #  }
-                FOrdStatus.CREATED: {
-                    FOrdStatus.PENDING_NEW: True,
-                    FOrdStatus.REJECTED: True,
-                    None: FIXError,
-                },
-                FOrdStatus.PENDING_NEW: {
-                    FOrdStatus.REJECTED: True,
-                    FOrdStatus.NEW: True,
-                    FOrdStatus.FILLED: True,
-                    FOrdStatus.PARTIALLY_FILLED: True,
-                    FOrdStatus.CANCELED: True,
-                    FOrdStatus.SUSPENDED: True,
-                    None: FIXError,
-                },
-                FOrdStatus.NEW: {
-                    FOrdStatus.NEW: None,
-                    FOrdStatus.PENDING_NEW: FIXError,
-                    FOrdStatus.CREATED: FIXError,
-                    FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
-                    None: True,
-                },
-                FOrdStatus.FILLED: {
-                    None: None,
-                },
-                FOrdStatus.CANCELED: {
-                    None: None,
-                },
-                FOrdStatus.REJECTED: {
-                    None: None,
-                },
-                FOrdStatus.EXPIRED: {
-                    None: None,
-                },
-                FOrdStatus.SUSPENDED: {
-                    FOrdStatus.NEW: True,
-                    FOrdStatus.PARTIALLY_FILLED: True,
-                    FOrdStatus.CANCELED: True,
-                    FOrdStatus.SUSPENDED: None,
-                    None: FIXError,
-                },
-                FOrdStatus.PARTIALLY_FILLED: {
-                    FOrdStatus.FILLED: True,
-                    FOrdStatus.PARTIALLY_FILLED: True,
-                    FOrdStatus.PENDING_REPLACE: True,
-                    FOrdStatus.PENDING_CANCEL: True,
-                    FOrdStatus.CANCELED: True,
-                    FOrdStatus.EXPIRED: True,
-                    FOrdStatus.SUSPENDED: True,
-                    FOrdStatus.STOPPED: True,
-                    None: FIXError,
-                },
-                FOrdStatus.PENDING_CANCEL: {
-                    FOrdStatus.CANCELED: True,
-                    FOrdStatus.CREATED: FIXError,
-                    None: None,
-                },
-                FOrdStatus.PENDING_REPLACE: {
-                    "exec_type": {
-                        FExecType.REPLACED: {
-                            FOrdStatus.NEW: True,
-                            FOrdStatus.PARTIALLY_FILLED: True,
-                            FOrdStatus.FILLED: True,
-                            FOrdStatus.CANCELED: True,
-                            None: FIXError,
-                        },
-                        None: {
-                            FOrdStatus.CREATED: FIXError,
-                            FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
-                            None: None,
-                        },
-                    },
-                },
-            }
-
-        elif fix_msg_type == FMsg.ORDERCANCELREJECT:  # '9'
-            status_transitions = {
-                None: {
-                    FOrdStatus.CREATED: FIXError,
-                    FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
-                    None: True,
-                }
-            }
-        elif (
-            fix_msg_type == FMsg.ORDERCANCELREQUEST
-            or fix_msg_type == FMsg.ORDERCANCELREPLACEREQUEST
-        ):
-            status_transitions = {
-                FOrdStatus.PENDING_CANCEL: {None: None},
-                FOrdStatus.PENDING_REPLACE: {None: None},
-                FOrdStatus.NEW: {None: True},
-                FOrdStatus.SUSPENDED: {None: True},
-                FOrdStatus.PARTIALLY_FILLED: {None: True},
-                None: {None: FIXError},
-            }
-
-        if not status_transitions:
-            raise FIXError(f"No status transition table for {fix_msg_type=}")
-
-        s = status_transitions.get(status, status_transitions[None])
-        if isinstance(s, dict) and "exec_type" in s:
-            s = s["exec_type"].get(msg_exec_type, s["exec_type"][None])
+        s = get_status_transitions(fix_msg_type, status, msg_exec_type)
         default = s[None]
         result = s.get(msg_status, default)
 

--- a/asyncfix/protocol/protocol_base.py
+++ b/asyncfix/protocol/protocol_base.py
@@ -8,5 +8,5 @@ class FIXProtocolBase:
     beginstring: str = "FIXProtocolBase"
     repeating_groups: dict[str, list[str]] = {}
     session_message_types: set = set()
-    fixtags: FTag = FTag
-    msgtype: FMsg = FMsg
+    fixtags: type[FTag] = FTag
+    msgtype: type[FMsg] = FMsg

--- a/asyncfix/protocol/schema.py
+++ b/asyncfix/protocol/schema.py
@@ -218,33 +218,20 @@ class SchemaSet:
 
     Attributes:
         name: schema name
-        field: schema field
         members: members
         required: required flag
     """
 
-    def __init__(self, name: str, field: SchemaField | None = None):
+    def __init__(self, name: str):
         """Initialize.
 
         Args:
             name: name of abstract set
-            field: field of abstract set
 
         Raises:
             ValueError: if not NUMINGROUP type or similar tag name
         """
         self.name = name
-        self.field = field  # this is set for groups, with attached field
-        if field:
-            if not (
-                ("No" in field.name or "Num" in field.name)
-                and field.ftype in ["NUMINGROUP", "INT"]
-            ):
-                # warnings.warn('')
-                raise ValueError(
-                    "SchemaSet expected to have group field with NUMINGROUP|INT type,"
-                    f" name contais No/Num, got {field}"
-                )
         self.members: dict[SchemaField | SchemaSet, SchemaField | SchemaSet] = {}
         self.required: dict[SchemaField | SchemaSet, bool] = {}
 
@@ -258,10 +245,7 @@ class SchemaSet:
         Raises:
             ValueError: raised then tag is not single field
         """
-        if self.field:
-            return self.field.tag
-        else:
-            raise ValueError(f"tag property is not supported for {self}")
+        raise ValueError(f"tag property is not supported for {self}")
 
     def keys(self) -> list[str]:
         """List of field names."""
@@ -279,7 +263,7 @@ class SchemaSet:
         """
         if isinstance(field_or_set, SchemaField):
             assert field_or_set not in self.members
-        elif isinstance(field_or_set, SchemaSet):
+        elif isinstance(field_or_set, SchemaGroup):
             assert field_or_set.field, "field_or_set.field is empty, try to merge"
         else:
             raise ValueError(f"Unsupported field_or_set type, got {type(field_or_set)}")
@@ -300,19 +284,13 @@ class SchemaSet:
 
     def __hash__(self):
         """Hash by field.name."""
-        if self.field:
-            return hash(self.field)
-        else:
-            return hash(self.name)
+        return hash(self.name)
 
     def __eq__(self, o):
         """Equality."""
-        if self.field:
-            return self.field == o
-        else:
-            return self.name == o
+        return self.name == o
 
-    def __contains__(self, item: str | SchemaField) -> bool:
+    def __contains__(self, item: str | SchemaField | SchemaSet) -> bool:
         """Check if SchemaSet contains field or name.
 
         Args:
@@ -330,7 +308,7 @@ class SchemaSet:
         except ValueError:
             return item in self.members
 
-    def __getitem__(self, item: str | SchemaField) -> SchemaField | SchemaSet:
+    def __getitem__(self, item: str | SchemaField | SchemaSet) -> SchemaField | SchemaSet:
         """Get field item by SchemaField or name.
 
         Args:
@@ -346,7 +324,7 @@ class SchemaSet:
             int(str(item))
             raise FIXMessageError("item looks like tag, use name or SchemaField")
         except ValueError:
-            return self.members[item]
+            return self.members[item]  # type: ignore
 
 
 class SchemaGroup(SchemaSet):
@@ -363,8 +341,38 @@ class SchemaGroup(SchemaSet):
             field: SchemaField of group
             required: required flag
         """
-        super().__init__(field.name, field)
+        super().__init__(field.name)
+        self.field = field
+        if not (
+            ("No" in field.name or "Num" in field.name)
+            and field.ftype in ["NUMINGROUP", "INT"]
+        ):
+            # warnings.warn('')
+            raise ValueError(
+                "SchemaSet expected to have group field with NUMINGROUP|INT type,"
+                f" name contais No/Num, got {field}"
+            )
         self.field_required = required
+
+    def __hash__(self):
+        """Hash by field.name."""
+        return hash(self.field)
+
+    def __eq__(self, o):
+        """Equality."""
+        return self.field == o
+
+    @property
+    def tag(self) -> str:
+        """Tag number of SchemaField.
+
+        Returns:
+            tag
+
+        Raises:
+            ValueError: raised then tag is not single field
+        """
+        return self.field.tag
 
     def validate_group(self, groups: list[FIXContainer]):
         """Validate values of all tags in group.
@@ -501,7 +509,7 @@ class FIXSchema:
         self._components: dict[str, SchemaComponent] = {}
         self._messages: dict[str, SchemaMessage] = {}
         self._messages_types: dict[str, SchemaMessage] = {}
-        self._types = set()
+        self._types: set[str] = set()
 
         self._parse(xml_or_path.getroot())
 
@@ -724,7 +732,7 @@ class FIXSchema:
                     raise FIXMessageError(
                         f"msg tag={tag} val={val} must be a tag, got group"
                     )
-                fschema.validate_value(val)
+                fschema.validate_value(val)  # type: ignore
 
             elif isinstance(fschema, SchemaGroup):
                 if not msg.is_group(tag):

--- a/asyncfix/protocol/schema.py
+++ b/asyncfix/protocol/schema.py
@@ -233,8 +233,8 @@ class SchemaSet:
         Raises:
             ValueError: if not NUMINGROUP type or similar tag name
         """
-        self.name: str = name
-        self.field: SchemaField = field  # this is set for groups, with attached field
+        self.name = name
+        self.field = field  # this is set for groups, with attached field
         if field:
             if not (
                 ("No" in field.name or "Num" in field.name)
@@ -497,11 +497,10 @@ class FIXSchema:
 
         self._tag2field: dict[str, SchemaField] = {}
         self._field2tag: dict[str, SchemaField] = {}
-        self._header: SchemaHeader = None
+        self._header: SchemaHeader = SchemaHeader()
         self._components: dict[str, SchemaComponent] = {}
         self._messages: dict[str, SchemaMessage] = {}
         self._messages_types: dict[str, SchemaMessage] = {}
-        self._header = {}
         self._types = set()
 
         self._parse(xml_or_path.getroot())
@@ -588,9 +587,14 @@ class FIXSchema:
 
     def _parse_header(self, element: ET.Element):
         assert self._field2tag, "parse fields first!"
-        assert element.tag == "header"
-
-        self._header = self._parse_msg_set(SchemaHeader(), element)
+        if (element_header := element.find("header")) is not None:
+            header = self._parse_msg_set(SchemaHeader(), element_header)
+            if header is not None:
+                self._header = header
+            else:
+                raise FIXMessageError("Failed to parse header")
+        else:
+            raise FIXMessageError("Header not found in schema")
 
     def _parse_field(self, element: ET.Element):
         assert element.tag == "field"
@@ -611,13 +615,17 @@ class FIXSchema:
 
     def _parse(self, root: ET.Element):
         assert not self._field2tag, "already parsed"
-
-        for element in root.find("fields"):
+        if (fields := root.find("fields")) is None:
+            raise FIXMessageError("No fields in schema")
+        for element in fields:
             self._parse_field(element)
 
-        self._parse_header(root.find("header"))
+        self._parse_header(root)
 
-        all_components = [e for e in root.find("components")]
+        if (components := root.find("components")) is None:
+            all_components = []
+        else:
+            all_components = [e for e in components]
         full_count = len(all_components)
         prev_cnt = len(all_components)
         while all_components:
@@ -641,13 +649,16 @@ class FIXSchema:
         assert full_count == len(self._components), "Component count mismatch"
 
         n_msg = 0
-        for element in root.find("messages"):
-            self._parse_message(element)
-            n_msg += 1
+        if (messages := root.find("messages")) is not None:
+            for element in messages:
+                self._parse_message(element)
+                n_msg += 1
 
         assert n_msg == len(self._messages), "Message count mismatch"
 
     def _validate_header(self, msg: FIXMessage):
+        if self._header is None:
+            return
         schema_fields = set()
         schema_msg = self._header
         for fname, req in schema_msg.required.items():

--- a/asyncfix/protocol/schema.py
+++ b/asyncfix/protocol/schema.py
@@ -687,7 +687,7 @@ class FIXSchema:
         if msg.msg_type not in self._messages_types:
             raise FIXMessageError(f"msg_type=`{msg.msg_type}` not in schema")
 
-        schema_msg = self._messages_types[msg.msg_type]
+        schema_msg = self._messages_types[str(msg.msg_type)]
 
         schema_fields = set()
         for fname, req in schema_msg.required.items():

--- a/asyncfix/protocol/transition.py
+++ b/asyncfix/protocol/transition.py
@@ -1,0 +1,154 @@
+from typing import Optional
+
+from asyncfix import FMsg
+from asyncfix.errors import FIXError
+from asyncfix.protocol.common import FOrdStatus, FExecType
+
+
+def get_status_transitions(
+    fix_msg_type: FMsg,
+    order_status: FOrdStatus,
+    msg_exec_type: FExecType,
+) -> dict[Optional[FOrdStatus], bool | type[FIXError] | None]:
+    match fix_msg_type:
+        case FMsg.EXECUTIONREPORT:
+            if order_status == FOrdStatus.PENDING_REPLACE:
+                return get_status_transitions_execution_report_pending_cancel(
+                    msg_exec_type
+                )
+            return get_status_transitions_execution_report(order_status)
+        case FMsg.ORDERCANCELREJECT:
+            return get_status_transitions_order_cancel_reject(order_status)
+        case FMsg.ORDERCANCELREQUEST | FMsg.ORDERCANCELREPLACEREQUEST:
+            return get_status_transitions_order_cancel_request(order_status)
+        case _:
+            raise FIXError(f"No status transition table for {fix_msg_type=}")
+
+
+def get_status_transitions_execution_report_pending_cancel(
+    msg_exec_type: FExecType,
+) -> dict[Optional[FOrdStatus], bool | type[FIXError] | None]:
+    statuses: dict[
+        Optional[FExecType], dict[Optional[FOrdStatus], bool | type[FIXError] | None]
+    ] = {
+        FExecType.REPLACED: {
+            FOrdStatus.NEW: True,
+            FOrdStatus.PARTIALLY_FILLED: True,
+            FOrdStatus.FILLED: True,
+            FOrdStatus.CANCELED: True,
+            None: FIXError,
+        },
+        None: {
+            FOrdStatus.CREATED: FIXError,
+            FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
+            None: None,
+        },
+    }
+    return statuses.get(msg_exec_type, statuses[None])
+
+
+def get_status_transitions_execution_report(
+    order_status: FOrdStatus,
+) -> dict[Optional[FOrdStatus], bool | type[FIXError] | None]:
+    statuses: dict[
+        Optional[FOrdStatus], dict[Optional[FOrdStatus], bool | type[FIXError] | None]
+    ] = {
+        None: {None: FIXError},
+        # key {initial status}: {
+        #    msg_status: <transition>,
+        #       <transition>: None - ignore, True - transit, FIXError - raise
+        #
+        #      REJECTED: True,     #  this is allowed status transition
+        #      PENDING_NEW: None,  #  transition allowed but no status change
+        #      CREATED: FIXError,  #  error transition
+        #      None:  [None, True, FIXError] # default transition
+        #  }
+        FOrdStatus.CREATED: {
+            FOrdStatus.PENDING_NEW: True,
+            FOrdStatus.REJECTED: True,
+            None: FIXError,
+        },
+        FOrdStatus.PENDING_NEW: {
+            FOrdStatus.REJECTED: True,
+            FOrdStatus.NEW: True,
+            FOrdStatus.FILLED: True,
+            FOrdStatus.PARTIALLY_FILLED: True,
+            FOrdStatus.CANCELED: True,
+            FOrdStatus.SUSPENDED: True,
+            None: FIXError,
+        },
+        FOrdStatus.NEW: {
+            FOrdStatus.NEW: None,
+            FOrdStatus.PENDING_NEW: FIXError,
+            FOrdStatus.CREATED: FIXError,
+            FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
+            None: True,
+        },
+        FOrdStatus.FILLED: {
+            None: None,
+        },
+        FOrdStatus.CANCELED: {
+            None: None,
+        },
+        FOrdStatus.REJECTED: {
+            None: None,
+        },
+        FOrdStatus.EXPIRED: {
+            None: None,
+        },
+        FOrdStatus.SUSPENDED: {
+            FOrdStatus.NEW: True,
+            FOrdStatus.PARTIALLY_FILLED: True,
+            FOrdStatus.CANCELED: True,
+            FOrdStatus.SUSPENDED: None,
+            None: FIXError,
+        },
+        FOrdStatus.PARTIALLY_FILLED: {
+            FOrdStatus.FILLED: True,
+            FOrdStatus.PARTIALLY_FILLED: True,
+            FOrdStatus.PENDING_REPLACE: True,
+            FOrdStatus.PENDING_CANCEL: True,
+            FOrdStatus.CANCELED: True,
+            FOrdStatus.EXPIRED: True,
+            FOrdStatus.SUSPENDED: True,
+            FOrdStatus.STOPPED: True,
+            None: FIXError,
+        },
+        FOrdStatus.PENDING_CANCEL: {
+            FOrdStatus.CANCELED: True,
+            FOrdStatus.CREATED: FIXError,
+            None: None,
+        },
+    }
+    return statuses.get(order_status, statuses[None])
+
+
+def get_status_transitions_order_cancel_reject(
+    order_status: FOrdStatus,
+) -> dict[Optional[FOrdStatus], bool | type[FIXError] | None]:
+    statuses: dict[
+        Optional[FOrdStatus], dict[Optional[FOrdStatus], bool | type[FIXError] | None]
+    ] = {
+        None: {
+            FOrdStatus.CREATED: FIXError,
+            FOrdStatus.ACCEPTED_FOR_BIDDING: FIXError,
+            None: True,
+        }
+    }
+    return statuses.get(order_status, statuses[None])
+
+
+def get_status_transitions_order_cancel_request(
+    order_status: FOrdStatus,
+) -> dict[Optional[FOrdStatus], bool | type[FIXError] | None]:
+    statuses: dict[
+        Optional[FOrdStatus], dict[Optional[FOrdStatus], bool | type[FIXError] | None]
+    ] = {
+        FOrdStatus.PENDING_CANCEL: {None: None},
+        FOrdStatus.PENDING_REPLACE: {None: None},
+        FOrdStatus.NEW: {None: True},
+        FOrdStatus.SUSPENDED: {None: True},
+        FOrdStatus.PARTIALLY_FILLED: {None: True},
+        None: {None: FIXError},
+    }
+    return statuses.get(order_status, statuses[None])

--- a/asyncfix/session.py
+++ b/asyncfix/session.py
@@ -22,16 +22,10 @@ class FIXSession:
             sender_comp_id: session sender
         """
         self.key = key
-        """Session DB ID / key."""
-
         self.sender_comp_id = sender_comp_id
         self.target_comp_id = target_comp_id
-
-        # Note: None is set intentionally, because session typically has to be
-        #   loaded or created by Journaler class, therefore it sets session values
-        #   internally
-        self.next_num_out: int | None = None
-        self.next_num_in: int | None = None
+        self.next_num_out: int = 0
+        self.next_num_in: int = 0
 
     def __hash__(self):
         """Hash by (target, sender)."""

--- a/asyncfix/session.py
+++ b/asyncfix/session.py
@@ -13,7 +13,7 @@ class FIXSession:
         next_num_in: next expected seq num in
     """
 
-    def __init__(self, key, target_comp_id: str, sender_comp_id: str):
+    def __init__(self, key: int, target_comp_id: str, sender_comp_id: str) -> None:
         """Initialize session.
 
         Args:
@@ -30,8 +30,8 @@ class FIXSession:
         # Note: None is set intentionally, because session typically has to be
         #   loaded or created by Journaler class, therefore it sets session values
         #   internally
-        self.next_num_out = None
-        self.next_num_in = None
+        self.next_num_out: int | None = None
+        self.next_num_in: int | None = None
 
     def __hash__(self):
         """Hash by (target, sender)."""

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -456,17 +456,7 @@ def test_encode_decode_pos_dup_flag(fix_session):
 def test_decode_custom_msg_type(fix_session):
     protocol = FIXProtocol44()
     codec = Codec(protocol)
-
-    msg = FIXMessage(codec.protocol.msgtype.NEWORDERSINGLE)
-    msg.set(codec.protocol.fixtags.Price, "123.45")
-    msg.set(codec.protocol.fixtags.OrderQty, 9876)
-    msg.set(codec.protocol.fixtags.Symbol, "VOD.L")
-    protocol = FIXProtocol44()
-    codec = Codec(protocol)
-    # enc_msg = codec.encode(msg, fix_session)
-    # print(repr(enc_msg))
-    # assert False, enc_msg
-
     enc_msg = b"8=FIX.4.4\x019=82\x0135=ASD\x0149=sender\x0156=target\x0134=1\x0152=20230919-07:13:26.808\x0144=123.45\x0138=9876\x0155=VOD.L\x0110=248\x01"  # noqa
-    msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
-    assert msg.msg_type == "ASD"
+    with pytest.raises(AssertionError, match="Invalid msg_type ASD"):
+        msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
+        assert msg.msg_type == "ASD"

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -1,6 +1,4 @@
 import datetime
-import importlib
-import unittest
 from unittest.mock import Mock, patch
 
 import pytest
@@ -85,51 +83,45 @@ def test_encode(fix_session):
 def test_decode_invalid_checksum(fix_session):
     protocol = FIXProtocol44()
     codec = Codec(protocol)
-
     msg = FIXMessage(codec.protocol.msgtype.NEWORDERSINGLE)
     msg.set(codec.protocol.fixtags.Price, "123.45")
     msg.set(codec.protocol.fixtags.OrderQty, 9876)
     msg.set(codec.protocol.fixtags.Symbol, "VOD.L")
-    protocol = FIXProtocol44()
-    codec = Codec(protocol)
     # enc_msg = codec.encode(msg, fix_session)
     # print(repr(enc_msg))
     # assert False, enc_msg
 
     enc_msg = b"8=FIX.4.4\x019=82\x0135=D\x0149=sender\x0156=target\x0134=1\x0152=20230919-07:13:26.808\x0144=123.45\x0138=9876\x0155=VOD.L\x0110=110\x01"  # noqa
-    msg, parsed_len, raw_msg = codec.decode(enc_msg)
+    decoded_msg, parsed_len, raw_msg = codec.decode(enc_msg)
 
-    assert msg is None
+    assert decoded_msg is None
     assert parsed_len == len(enc_msg)
 
     with pytest.raises(AssertionError, match="invalid checksum tag"):
-        msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
+        decoded_msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
 
 
 def test_decode_valid(fix_session):
     protocol = FIXProtocol44()
     codec = Codec(protocol)
-
     msg = FIXMessage(codec.protocol.msgtype.NEWORDERSINGLE)
     msg.set(codec.protocol.fixtags.Price, "123.45")
     msg.set(codec.protocol.fixtags.OrderQty, 9876)
     msg.set(codec.protocol.fixtags.Symbol, "VOD.L")
-    protocol = FIXProtocol44()
-    codec = Codec(protocol)
     # enc_msg = codec.encode(msg, fix_session)
     # print(repr(enc_msg))
     # assert False, enc_msg
 
     enc_msg = b"8=FIX.4.4\x019=82\x0135=D\x0149=sender\x0156=target\x0134=1\x0152=20230919-07:13:26.808\x0144=123.45\x0138=9876\x0155=VOD.L\x0110=100\x01"  # noqa
-    msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
+    decoded_msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
 
-    assert isinstance(msg, FIXMessage)
-    assert msg[8] == "FIX.4.4"
-    assert msg.msg_type == FMsg.NEWORDERSINGLE
-    assert isinstance(msg.msg_type, FMsg)
-    assert msg[FTag.Price] == "123.45"
-    assert msg[FTag.OrderQty] == "9876"
-    assert msg[FTag.Symbol] == "VOD.L"
+    assert isinstance(decoded_msg, FIXMessage)
+    assert decoded_msg[8] == "FIX.4.4"
+    assert decoded_msg.msg_type == FMsg.NEWORDERSINGLE
+    assert isinstance(decoded_msg.msg_type, FMsg)
+    assert decoded_msg[FTag.Price] == "123.45"
+    assert decoded_msg[FTag.OrderQty] == "9876"
+    assert decoded_msg[FTag.Symbol] == "VOD.L"
     assert parsed_len == len(enc_msg)
     assert raw_msg == enc_msg
 
@@ -248,14 +240,14 @@ def test_decode_groups(fix_session):
     # print(repr(msg_out))
     # assert False, enc_msg
 
-    g = msg_out.get_group_list(FTag.NoSecurityAltID)
-    assert g
-    assert isinstance(g, list)
-    assert len(g) == 2
-    assert g[0][FTag.SecurityAltID] == "abc"
-    assert g[0][FTag.SecurityAltIDSource] == "bbb"
-    assert g[1][FTag.SecurityAltID] == "zzz"
-    assert g[1][FTag.SecurityAltIDSource] == "xxx"
+    group_list = msg_out.get_group_list(FTag.NoSecurityAltID)
+    assert group_list
+    assert isinstance(group_list, list)
+    assert len(group_list) == 2
+    assert group_list[0][FTag.SecurityAltID] == "abc"
+    assert group_list[0][FTag.SecurityAltIDSource] == "bbb"
+    assert group_list[1][FTag.SecurityAltID] == "zzz"
+    assert group_list[1][FTag.SecurityAltIDSource] == "xxx"
 
     with pytest.raises(RepeatingTagError, match="tag=.*was repeated"):
         msg_out["20323"]
@@ -264,10 +256,10 @@ def test_decode_groups(fix_session):
         UnmappedRepeatedGrpError,
         match="tag exists, but it does not belong to any group",
     ):
-        g = msg_out.get_group_list("20228")
+        _ = msg_out.get_group_list("20228")
 
     with pytest.raises(TagNotFoundError, match="missing tag group tag="):
-        g = msg_out.get_group_list("129012099")
+        _ = msg_out.get_group_list("129012099")
 
 
 def test_decode_protocol_mismatch(fix_session):
@@ -340,12 +332,12 @@ def test_decode_with_unicode_valid(fix_session):
     # print(repr(enc_msg))
     # assert False, enc_msg
 
-    msg, parsed_len, raw_msg = codec.decode(enc_msg)
-    assert msg is None
+    decoded_msg, parsed_len, raw_msg = codec.decode(enc_msg)
+    assert decoded_msg is None
     assert parsed_len == len(enc_msg)
 
     with pytest.raises(AssertionError, match="invalid checksum tag"):
-        msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
+        decoded_msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
 
 
 def test_decode_empty_tag(fix_session):
@@ -390,6 +382,7 @@ def test_encode_decode_seqnum_reset_gap_fill(fix_session):
     enc_msg = codec.encode(msg, fix_session)
     msg_dec, parsed_len, raw_msg = codec.decode(enc_msg.encode())
 
+    assert msg_dec is not None
     assert msg_dec[34] == "3"
     assert msg_dec[FTag.GapFillFlag] == "Y"
 
@@ -405,6 +398,7 @@ def test_encode_decode_seqnum_reset_gap_fill_no(fix_session):
     enc_msg = codec.encode(msg, fix_session)
     msg_dec, parsed_len, raw_msg = codec.decode(enc_msg.encode())
 
+    assert msg_dec is not None
     assert msg_dec[34] == "3"
     assert FTag.GapFillFlag not in msg_dec
     assert FTag.NewSeqNo not in msg_dec
@@ -437,6 +431,8 @@ def test_encode_decode_pos_dup_flag(fix_session):
     enc_msg = codec.encode(msg, fix_session)
     msg_dec, parsed_len, raw_msg = codec.decode(enc_msg.encode())
 
+    assert msg_dec is not None
+    assert msg_dec is not None
     assert msg_dec[34] == "7"
     assert msg_dec[FTag.PossDupFlag] == "Y"
 
@@ -459,4 +455,5 @@ def test_decode_custom_msg_type(fix_session):
     enc_msg = b"8=FIX.4.4\x019=82\x0135=ASD\x0149=sender\x0156=target\x0134=1\x0152=20230919-07:13:26.808\x0144=123.45\x0138=9876\x0155=VOD.L\x0110=248\x01"  # noqa
     with pytest.raises(AssertionError, match="Invalid msg_type ASD"):
         msg, parsed_len, raw_msg = codec.decode(enc_msg, silent=False)
+        assert msg is not None
         assert msg.msg_type == "ASD"

--- a/tests/test_codec.py
+++ b/tests/test_codec.py
@@ -19,7 +19,7 @@ from asyncfix.protocol import FIXProtocol44
 
 class FakeDate(datetime.datetime):
     @classmethod
-    def utcnow(cls):
+    def now(cls, tz=None):
         return cls(2015, 6, 19, 11, 8, 54)
 
 

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -8,7 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 import pytest_asyncio
 
-from asyncfix import FIXMessage, FIXTester, FMsg, FTag
+from asyncfix import FIXMessage, FIXTester, FIXConnTester, FMsg, FTag
 from asyncfix.connection import AsyncFIXConnection, ConnectionRole, ConnectionState
 from asyncfix.errors import FIXConnectionError, FIXMessageError
 from asyncfix.journaler import Journaler
@@ -80,7 +80,7 @@ async def fix_connection():
 @pytest.mark.asyncio
 async def test_connection_send_not_connected_error(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
     msg = ft.msg_logon()
 
     for state in [
@@ -101,7 +101,7 @@ async def test_connection_send_not_connected_error(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_send_first_logon_sets_state(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._connection_state = ConnectionState.NETWORK_CONN_ESTABLISHED
     msg = ft.msg_logon()
@@ -122,7 +122,7 @@ async def test_connection_send_first_logon_sets_state(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_send_first_must_be_logon(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._connection_state = ConnectionState.NETWORK_CONN_ESTABLISHED
     msg = ft.msg_sequence_reset(1, 12)
@@ -141,7 +141,7 @@ async def test_connection_send_first_must_be_logon(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_logon_acceptor_logon(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     assert conn._connection_state == ConnectionState.NETWORK_CONN_ESTABLISHED
     _ = await ft.reply(ft.msg_logon())
@@ -152,7 +152,7 @@ async def test_connection_logon_acceptor_logon(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_logon_acceptor_logon_first_message_expected(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     assert conn._connection_state == ConnectionState.NETWORK_CONN_ESTABLISHED
     msg_reset = ft.msg_sequence_reset(1, 2)
@@ -163,7 +163,7 @@ async def test_connection_logon_acceptor_logon_first_message_expected(fix_connec
 @pytest.mark.asyncio
 async def test_connection_logon_valid(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -196,7 +196,7 @@ async def test_connection_logon_valid(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_logon_low_seq_num_by_initator(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 20
     ft.set_next_num(num_in=21)
@@ -229,7 +229,7 @@ async def test_connection_logon_low_seq_num_by_initator(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_logon_low_seq_num_by_acceptor(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -263,7 +263,7 @@ async def test_connection_logon_low_seq_num_by_acceptor(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_missing_seqnum(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -277,7 +277,7 @@ async def test_connection_validation_missing_seqnum(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_seqnum_toolow(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 20
 
@@ -293,7 +293,7 @@ async def test_connection_validation_seqnum_toolow(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_seqnum_toolow__possdup__in_active(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=None, connection=conn)
+    ft = FIXConnTester(conn, schema=None)
 
     conn._session.next_num_out = 20
     conn._connection_state = ConnectionState.ACTIVE
@@ -312,7 +312,7 @@ async def test_connection_validation_seqnum_toolow__possdup__in_active(fix_conne
 @pytest.mark.asyncio
 async def test_connection_validation_seqnum_toolow_poss_dup_flag(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=None, connection=conn)
+    ft = FIXConnTester(conn, schema=None)
 
     conn._session.next_num_out = 20
     conn._connection_state = ConnectionState.RESENDREQ_AWAITING
@@ -330,7 +330,7 @@ async def test_connection_validation_seqnum_toolow_poss_dup_flag(fix_connection)
 @pytest.mark.asyncio
 async def test_connection_validation_beginstring(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -347,7 +347,7 @@ async def test_connection_validation_beginstring(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_no_target(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -361,7 +361,7 @@ async def test_connection_validation_no_target(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_no_sender(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -375,7 +375,7 @@ async def test_connection_validation_no_sender(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_sender_mismatch(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -389,7 +389,7 @@ async def test_connection_validation_sender_mismatch(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_validation_target_mismatch(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -403,7 +403,7 @@ async def test_connection_validation_target_mismatch(fix_connection):
 @pytest.mark.asyncio
 async def test_connection__process_resend_req_synth(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     with patch.object(conn, "_journaler") as mock__journaler:
         msgs = [
@@ -469,7 +469,7 @@ async def test_connection__process_resend_req_synth(fix_connection):
 @pytest.mark.asyncio
 async def test_sequence_reset_request__incoming_seq_num_toolow_ignored(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -500,7 +500,7 @@ async def test_sequence_reset_request__incoming_seq_num_toolow_ignored(fix_conne
 @pytest.mark.asyncio
 async def test_sequence_reset_request__no_gap(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -530,7 +530,7 @@ async def test_sequence_reset_request__no_gap(fix_connection):
 @pytest.mark.asyncio
 async def test_sequence_reset_request__unexpected_gapfillflag(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -556,7 +556,7 @@ async def test_sequence_reset_request__unexpected_gapfillflag(fix_connection):
 @pytest.mark.asyncio
 async def test__finalize_message(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_sequence_reset(1, 10, is_gap_fill=True)
     assert conn._message_last_time == 0
@@ -604,7 +604,7 @@ async def test__finalize_message(fix_connection):
 @pytest.mark.asyncio
 async def test_connection_both_seqnum_mismach_bidirectional_resend_req(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 20
     conn._session.next_num_in = 25
@@ -627,7 +627,7 @@ async def test_connection_both_seqnum_mismach_bidirectional_resend_req(fix_conne
 @pytest.mark.asyncio
 async def test_test_request_exchange(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -646,7 +646,7 @@ async def test_test_request_exchange(fix_connection):
 @pytest.mark.asyncio
 async def test_test_incorrect_response(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -677,7 +677,7 @@ async def test_test_incorrect_response(fix_connection):
 @pytest.mark.asyncio
 async def test_test_request_errors_side_cases(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     msg = ft.msg_logon()
     await conn.send_msg(msg)
@@ -717,7 +717,7 @@ async def test_test_request_errors_side_cases(fix_connection):
 @pytest.mark.asyncio
 async def test_extra_msg_during_seq_num_resend_alredy_journaled(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 20
     conn._session.next_num_in = 25
@@ -749,7 +749,7 @@ async def test_extra_msg_during_seq_num_resend_alredy_journaled(fix_connection):
 @pytest.mark.asyncio
 async def test_extra_msg_during_seq_num_resend_low_num_not_processed(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 20
     conn._session.next_num_in = 25
@@ -786,7 +786,7 @@ async def test_extra_msg_during_seq_num_resend_low_num_not_processed(fix_connect
 @pytest.mark.asyncio
 async def test_connection__process_resend_req_real_processing(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     with (
         patch.object(conn, "_journaler") as mock__journaler,
@@ -817,7 +817,7 @@ async def test_connection__process_resend_req_real_processing(fix_connection):
 @pytest.mark.asyncio
 async def test_connection__process_resend__ignores_high_seq_num_msg(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._session.next_num_out = 10
 
@@ -871,7 +871,7 @@ async def test_connection__process_resend__ignores_high_seq_num_msg(fix_connecti
 @pytest.mark.asyncio
 async def test_connection_init_launch_tasks(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     journaler_mock = MagicMock()
     with (
@@ -1479,7 +1479,7 @@ async def test_heartbeat_task__test_req_sent(fix_connection_socket, fix_msg):
 @pytest.mark.asyncio
 async def test_process_logout(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     conn._connection_state = ConnectionState.ACTIVE
 
@@ -1496,7 +1496,7 @@ async def test_process_logout(fix_connection):
 @pytest.mark.asyncio
 async def test_reset_seqnum(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
     conn._session.next_num_in = 3
     conn._session.next_num_out = 5
 
@@ -1518,7 +1518,7 @@ async def test_reset_seqnum(fix_connection):
 @pytest.mark.asyncio
 async def test_connection__process_resend_req__dupe_journal_seqnum(fix_connection):
     conn: AsyncFIXConnection = fix_connection
-    ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
+    ft = FIXConnTester(conn, schema=FIX_SCHEMA)
 
     with patch.object(conn._journaler, "recover_messages") as mock__recover_msg:
         msgs = [

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -2,7 +2,6 @@ import asyncio
 import logging
 import os
 import time
-import warnings
 import xml.etree.ElementTree as ET
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -11,7 +10,7 @@ import pytest_asyncio
 
 from asyncfix import FIXMessage, FIXTester, FMsg, FTag
 from asyncfix.connection import AsyncFIXConnection, ConnectionRole, ConnectionState
-from asyncfix.errors import FIXConnectionError
+from asyncfix.errors import FIXConnectionError, FIXMessageError
 from asyncfix.journaler import Journaler
 from asyncfix.message import MessageDirection
 from asyncfix.protocol import FIXProtocol44, FIXSchema
@@ -69,7 +68,7 @@ async def fix_connection():
         "ACCEPTOR",
         journaler=j,
         host="localhost",
-        port="64444",
+        port=64444,
         heartbeat_period=30,
         logger=log,
     )
@@ -271,7 +270,8 @@ async def test_connection_validation_missing_seqnum(fix_connection):
     msg_out = ft.initiator_sent[-1]
 
     del msg_out[34]
-    assert ft.conn_accept._validate_integrity(msg_out) == "MsgSeqNum(34) tag is missing"
+    with pytest.raises(FIXMessageError, match=r"MsgSeqNum\(34\) tag is missing"):
+        ft.conn_accept._validate_integrity(msg_out)
 
 
 @pytest.mark.asyncio
@@ -286,10 +286,8 @@ async def test_connection_validation_seqnum_toolow(fix_connection):
     msg_out = ft.initiator_sent[-1]
     ft.set_next_num(num_in=21)
 
-    assert (
+    with pytest.raises(FIXMessageError, match="MsgSeqNum is too low, expected 21, got 20"):
         ft.conn_accept._validate_integrity(msg_out)
-        == "MsgSeqNum is too low, expected 21, got 20"
-    )
 
 
 @pytest.mark.asyncio
@@ -307,10 +305,8 @@ async def test_connection_validation_seqnum_toolow__possdup__in_active(fix_conne
 
     assert conn._connection_state == ConnectionState.ACTIVE
     assert msg_out[FTag.PossDupFlag] == "Y"
-    assert (
+    with pytest.raises(FIXMessageError, match="MsgSeqNum is too low, expected 21, got 19"):
         ft.conn_accept._validate_integrity(msg_out)
-        == "MsgSeqNum is too low, expected 21, got 19"
-    )
 
 
 @pytest.mark.asyncio
@@ -341,10 +337,11 @@ async def test_connection_validation_beginstring(fix_connection):
     msg_out = ft.initiator_sent[-1]
     msg_out.set(FTag.BeginString, "FIX4.8", replace=True)
 
-    assert (
+    with pytest.raises(
+        FIXMessageError,
+        match=r"Protocol BeginString\(8\) mismatch, expected FIX\.4\.4, got FIX4\.8",
+    ):
         ft.conn_accept._validate_integrity(msg_out)
-        == "Protocol BeginString(8) mismatch, expected FIX.4.4, got FIX4.8"
-    )
 
 
 @pytest.mark.asyncio
@@ -357,7 +354,8 @@ async def test_connection_validation_no_target(fix_connection):
     msg_out = ft.initiator_sent[-1]
     del msg_out[FTag.TargetCompID]
 
-    assert conn._validate_integrity(msg_out) is True
+    with pytest.raises(FIXMessageError, match=''):
+        conn._validate_integrity(msg_out)
 
 
 @pytest.mark.asyncio
@@ -370,7 +368,8 @@ async def test_connection_validation_no_sender(fix_connection):
     msg_out = ft.initiator_sent[-1]
     del msg_out[FTag.SenderCompID]
 
-    assert conn._validate_integrity(msg_out) is True
+    with pytest.raises(FIXMessageError, match=''):
+        conn._validate_integrity(msg_out)
 
 
 @pytest.mark.asyncio
@@ -383,7 +382,8 @@ async def test_connection_validation_sender_mismatch(fix_connection):
     msg_out = ft.initiator_sent[-1]
     msg_out.set(FTag.SenderCompID, "as", replace=True)
 
-    assert conn._validate_integrity(msg_out) == "TargetCompID / SenderCompID mismatch"
+    with pytest.raises(FIXMessageError, match="TargetCompID / SenderCompID mismatch"):
+        conn._validate_integrity(msg_out)
 
 
 @pytest.mark.asyncio
@@ -396,7 +396,8 @@ async def test_connection_validation_target_mismatch(fix_connection):
     msg_out = ft.initiator_sent[-1]
     msg_out.set(FTag.TargetCompID, "as", replace=True)
 
-    assert conn._validate_integrity(msg_out) == "TargetCompID / SenderCompID mismatch"
+    with pytest.raises(FIXMessageError, match="TargetCompID / SenderCompID mismatch"):
+        conn._validate_integrity(msg_out)
 
 
 @pytest.mark.asyncio

--- a/tests/test_connection.py
+++ b/tests/test_connection.py
@@ -41,7 +41,7 @@ async def fix_connection_socket():
         "ACCEPTOR",
         journaler=j,
         host="localhost",
-        port="64444",
+        port=64444,
         heartbeat_period=30,
         logger=log,
     )
@@ -144,7 +144,7 @@ async def test_connection_logon_acceptor_logon(fix_connection):
     ft = FIXTester(schema=FIX_SCHEMA, connection=conn)
 
     assert conn._connection_state == ConnectionState.NETWORK_CONN_ESTABLISHED
-    rmsg = await ft.reply(ft.msg_logon())
+    _ = await ft.reply(ft.msg_logon())
     assert conn.connection_role == ConnectionRole.ACCEPTOR
     assert conn._connection_state == ConnectionState.ACTIVE
 
@@ -156,7 +156,7 @@ async def test_connection_logon_acceptor_logon_first_message_expected(fix_connec
 
     assert conn._connection_state == ConnectionState.NETWORK_CONN_ESTABLISHED
     msg_reset = ft.msg_sequence_reset(1, 2)
-    rmsg = await ft.reply(msg_reset)
+    _ = await ft.reply(msg_reset)
     assert conn._connection_state == ConnectionState.DISCONNECTED_BROKEN_CONN
 
 
@@ -885,7 +885,7 @@ async def test_connection_init_launch_tasks(fix_connection):
             "ACCEPTOR",
             journaler=journaler_mock,
             host="localhost",
-            port="64444",
+            port=64444,
             heartbeat_period=33,
         )
 

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,5 +1,4 @@
 import pickle
-import unittest
 
 import pytest
 
@@ -27,9 +26,9 @@ def test_tag_errors():
     msg = FIXMessage("AB")
     msg["45"] = "dgd"
 
-    with pytest.raises(TagNotFoundError) as exc:
-        msg["99"]
-    with pytest.raises(TagNotFoundError) as exc:
+    with pytest.raises(TagNotFoundError):
+        msg["99"]  # noqa
+    with pytest.raises(TagNotFoundError):
         msg.get("99")
 
     assert msg.get("99", 100) == 100
@@ -48,7 +47,7 @@ def test_tag_errors():
     with pytest.raises(
         RepeatingTagError, match="tag=45 was repeated, possible undefined "
     ):
-        msg[45]
+        msg[45]  # noqa
 
 
 def test_groups():
@@ -76,7 +75,7 @@ def test_groups():
     msg.add_group(2023, {1: "e", 4: "f"})
 
     with pytest.raises(FIXMessageError, match="Expected FIXContext in group, got "):
-        msg.add_group(2023, None)
+        msg.add_group(2023, None)  # noqa
 
     g = msg.get_group_by_index(2023, 0)
     assert isinstance(g, FIXContainer)
@@ -148,8 +147,7 @@ def test_msg_construction():
     rptgrp2 = FIXContainer({611: "zzz", 612: "yyy", "613": "xxx"})
     msg.add_group("444", rptgrp2, 1)
 
-    assert "45=dgd|32=aaaa|323=bbbb|444=2=>[611=aaa|612=bbb|613=ccc,"
-    " 611=zzz|612=yyy|613=xxx]" == str(msg)
+    assert str(msg) == "45=dgd|32=aaaa|323=bbbb|444=2=>[611=aaa|612=bbb|613=ccc, 611=zzz|612=yyy|613=xxx]"
 
     msg.add_group("444", rptgrp2, 1)
 
@@ -158,11 +156,10 @@ def test_msg_construction():
     rptgrp3.set("612", "hhh")
     rptgrp3.set("613", "jjj")
     rptgrp2.add_group("445", rptgrp3, 0)
-    assert "45=dgd|32=aaaa|323=bbbb|444=2=>[611=aaa|612=bbb|613=ccc,"
-    " 611=zzz|612=yyy|613=xxx|445=1=>[611=ggg|612=hhh|613=jjj]]" == str(msg)
+    assert str(msg) == "45=dgd|32=aaaa|323=bbbb|444=3=>[611=aaa|612=bbb|613=ccc, 611=zzz|612=yyy|613=xxx|445=1=>[611=ggg|612=hhh|613=jjj], 611=zzz|612=yyy|613=xxx|445=1=>[611=ggg|612=hhh|613=jjj]]"
 
     grp = msg.get_group_by_tag("444", "612", "yyy")
-    assert "611=zzz|612=yyy|613=xxx|445=1=>[611=ggg|612=hhh|613=jjj]" == str(grp)
+    assert str(grp) == "611=zzz|612=yyy|613=xxx|445=1=>[611=ggg|612=hhh|613=jjj]"
 
 
 def testPickle():

--- a/tests/test_protocol_common.py
+++ b/tests/test_protocol_common.py
@@ -1,6 +1,4 @@
-import pytest
-
-from asyncfix.protocol.common import FExecType, FOrdSide, FOrdStatus, FOrdType
+from asyncfix.protocol.common import FExecType, FOrdSide, FOrdStatus
 
 
 def test_exec_type():

--- a/tests/test_protocol_order_single.py
+++ b/tests/test_protocol_order_single.py
@@ -6,9 +6,9 @@ import pytest
 
 from asyncfix import FIXTester, FMsg, FTag
 from asyncfix.errors import FIXError
-from asyncfix.protocol.common import FExecType, FOrdSide, FOrdStatus, FOrdType
-from asyncfix.protocol.order_single import FIXNewOrderSingle
-from asyncfix.protocol.schema import FIXSchema
+from asyncfix.protocol import FExecType, FOrdSide, FOrdStatus, FOrdType
+from asyncfix.protocol import FIXNewOrderSingle
+from asyncfix.protocol import FIXSchema
 
 TEST_DIR = os.path.abspath(os.path.dirname(__file__))
 fix44_schema = ET.parse(os.path.join(TEST_DIR, "FIX44.xml"))

--- a/tests/test_protocol_order_single.py
+++ b/tests/test_protocol_order_single.py
@@ -1,6 +1,4 @@
 import os
-import time
-import unittest
 import xml.etree.ElementTree as ET
 from math import isnan, nan
 
@@ -18,7 +16,6 @@ FIX_SCHEMA = FIXSchema(fix44_schema)
 
 
 def test_init_order_single_default_short():
-    ord_dict = {}
     o = FIXNewOrderSingle(
         "clordTest", "US.F.TICKER", side=FOrdSide.SELL, price=100.0, qty=20
     )
@@ -709,7 +706,7 @@ def test_cancel_req():
     o = FIXNewOrderSingle(
         "clordTest", "US.F.TICKER", side=FOrdSide.SELL, price=100.0, qty=20
     )
-    new_req = o.new_req()
+    _ = o.new_req()
     o.status = FOrdStatus.NEW
 
     m = o.cancel_req()
@@ -922,7 +919,7 @@ def test_cancel_req__part_filled_order__with_some_execution_between():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_cxl_request(o)
+    _ = ft.fix_cxl_request(o)
     assert o.status == FOrdStatus.PENDING_CANCEL
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
@@ -1119,7 +1116,7 @@ def test_cancel_req__not_acknoledged_order_by_gate():
     assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     with pytest.raises(FIXError, match="order is not allowed for cancel"):
-        cxl_req = o.cancel_req()
+        _ = o.cancel_req()
     assert not o.can_replace()
     assert not o.can_cancel()
 
@@ -1129,7 +1126,7 @@ def test_cancel_req__not_acknoledged_order_by_gate():
     assert o.process_execution_report(msg) == 1
 
     with pytest.raises(FIXError, match="order is not allowed for cancel"):
-        cxl_req = o.cancel_req()
+        _ = o.cancel_req()
     assert not o.can_replace()
     assert not o.can_cancel()
 
@@ -1153,7 +1150,7 @@ def test_cancel_req__multiple_requests_are_blocked():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_cxl_request(o)
+    _ = ft.fix_cxl_request(o)
     assert o.status == FOrdStatus.PENDING_CANCEL
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
@@ -1218,7 +1215,7 @@ def test_replace_req():
     o.new_req()
     o.status = FOrdStatus.NEW
 
-    old_clord = o.clord_id
+    _ = o.clord_id
     assert o.can_replace()
     m = o.replace_req(200, 30)
     assert not o.can_replace()
@@ -1286,15 +1283,15 @@ def test_replace_req__not_set():
     o.status = FOrdStatus.NEW
 
     with pytest.raises(FIXError, match="no price / qty change in replace_req"):
-        m = o.replace_req(nan, nan)
+        _ = o.replace_req(nan, nan)
 
     # No change in price/qty
     with pytest.raises(FIXError, match="no price / qty change in replace_req"):
-        m = o.replace_req(o.price, o.qty)
+        _ = o.replace_req(o.price, o.qty)
 
     # No change in price/qty
     with pytest.raises(FIXError, match="no price / qty change in replace_req"):
-        m = o.replace_req(o.price, 0)
+        _ = o.replace_req(o.price, 0)
 
 
 def test_replace_req__zero_filled__increased_qty():
@@ -1320,7 +1317,7 @@ def test_replace_req__zero_filled__increased_qty():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_rep_request(o, 300, 11)
+    _ = ft.fix_rep_request(o, 300, 11)
     assert o.status == FOrdStatus.PENDING_REPLACE
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
@@ -1404,7 +1401,7 @@ def test_replace_req__part_filled__increased_qty_while_pending_replace_fractiona
     assert o.process_execution_report(msg) == 1
     old_clord = o.clord_id
 
-    cxl_req = ft.fix_rep_request(o, 300, 12)
+    _ = ft.fix_rep_request(o, 300, 12)
     assert o.status == FOrdStatus.PENDING_REPLACE
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
@@ -1624,7 +1621,7 @@ def test_replace_req__filled_order_rejected__filled_increase_passed():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_rep_request(o, 300, 12)
+    _ = ft.fix_rep_request(o, 300, 12)
     assert o.status == FOrdStatus.PENDING_REPLACE
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
@@ -1808,7 +1805,7 @@ def test_replace_req__decreased_qty():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_rep_request(o, nan, 9)
+    _ = ft.fix_rep_request(o, nan, 9)
     assert o.status == FOrdStatus.PENDING_REPLACE
 
     msg = ft.fix_exec_report_msg(
@@ -1871,7 +1868,7 @@ def test_replace_req__decreased_qty_exact_match_to_fill():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_rep_request(o, nan, 7)
+    _ = ft.fix_rep_request(o, nan, 7)
     assert o.status == FOrdStatus.PENDING_REPLACE
 
     msg = ft.fix_exec_report_msg(
@@ -1933,7 +1930,7 @@ def test_replace_req__decreased_qty__also_less_than_cum_qty():
     )
     assert o.process_execution_report(msg) == 1
 
-    cxl_req = ft.fix_rep_request(o, nan, 7)
+    _ = ft.fix_rep_request(o, nan, 7)
     assert o.status == FOrdStatus.PENDING_REPLACE
 
     msg = ft.fix_exec_report_msg(

--- a/tests/test_protocol_order_single.py
+++ b/tests/test_protocol_order_single.py
@@ -1403,6 +1403,7 @@ def test_replace_req__part_filled__increased_qty_while_pending_replace_fractiona
 
     _ = ft.fix_rep_request(o, 300, 12)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
     assert o.is_finished() == 0
@@ -1557,6 +1558,7 @@ def test_replace_req__filled_order_rejected_after_filled():
 
     cxl_req = ft.fix_rep_request(o, 300, 12)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
     assert o.is_finished() == 0
@@ -1623,6 +1625,7 @@ def test_replace_req__filled_order_rejected__filled_increase_passed():
 
     _ = ft.fix_rep_request(o, 300, 12)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
     assert o.is_finished() == 0
@@ -1733,6 +1736,7 @@ def test_replace_req__replace_price_only_but_rejected_because_fill():
 
     cxl_req = ft.fix_rep_request(o, 300, nan)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
     assert o.can_replace() == 0
     assert o.can_cancel() == 0
     assert o.is_finished() == 0
@@ -1807,6 +1811,7 @@ def test_replace_req__decreased_qty():
 
     _ = ft.fix_rep_request(o, nan, 9)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
 
     msg = ft.fix_exec_report_msg(
         o,
@@ -1870,6 +1875,7 @@ def test_replace_req__decreased_qty_exact_match_to_fill():
 
     _ = ft.fix_rep_request(o, nan, 7)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
 
     msg = ft.fix_exec_report_msg(
         o,
@@ -1932,6 +1938,7 @@ def test_replace_req__decreased_qty__also_less_than_cum_qty():
 
     _ = ft.fix_rep_request(o, nan, 7)
     assert o.status == FOrdStatus.PENDING_REPLACE
+    assert o.orig_clord_id is not None
 
     msg = ft.fix_exec_report_msg(
         o,

--- a/tests/test_protocol_order_single.py
+++ b/tests/test_protocol_order_single.py
@@ -142,13 +142,13 @@ def test_simple_execution_report_state_created__2__pending_new():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={o.status}"
 
 
 def test_simple_execution_report_state_created__2__rejected():
@@ -158,11 +158,11 @@ def test_simple_execution_report_state_created__2__rejected():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(o, o.clord_id, FExecType.REJECTED, FOrdStatus.REJECTED)
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.REJECTED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.REJECTED, f"o.status={o.status}"
 
 
 def test_state_transition__unsupported_msg():
@@ -181,9 +181,9 @@ def test_state_transition__created__execution_report():
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.CANCELED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.STOPPED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CREATED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CREATED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.CREATED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) 
@@ -194,15 +194,15 @@ def test_state_transition__created__execution_report():
 def test_state_transition__pendingnew__execution_report():
     # fmt: off
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.NEW) == FOrdStatus.NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) == FOrdStatus.NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.STOPPED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.CALCULATED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_NEW, '8', FExecType.TRADE, FOrdStatus.EXPIRED) 
@@ -215,115 +215,115 @@ def test_state_transition__new__execution_report():
     # fmt: off
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.CREATED)
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
+    assert FIXNewOrderSingle.change_status(FOrdStatus.NEW, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
     # fmt: on
 
 
 def test_state_transition__rejected__execution_report():
     # fmt: off
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.CREATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.CANCELED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CREATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.REJECTED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
     # fmt: on
 
 
 def test_state_transition__filled__execution_report():
     # fmt: off
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.CREATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.CANCELED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CREATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
     # fmt: on
 
 
 def test_state_transition__expired__execution_report():
     # fmt: off
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.CREATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.CANCELED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CREATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.EXPIRED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
     # fmt: on
 
 
 def test_state_transition__canceled__execution_report():
     # fmt: off
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.CREATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.CANCELED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CREATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.CANCELED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
     # fmt: on
 
 
 def test_state_transition__suspended__execution_report():
     # fmt: off
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.NEW) == FOrdStatus.NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) == FOrdStatus.NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.FILLED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.STOPPED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.REJECTED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.SUSPENDED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.SUSPENDED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) 
@@ -336,19 +336,19 @@ def test_state_transition__partiallyfilled__execution_report():
     # fmt: off
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.CREATED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.NEW) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) == FOrdStatus.FILLED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.REJECTED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.CALCULATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PARTIALLY_FILLED, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
     # fmt: on
 
 
@@ -356,37 +356,37 @@ def test_state_transition__pendingcancel__execution_report():
     # fmt: off
     # Executin report doesn't not have any effect of pending cancelled state
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
 
     # But cancel reject request does!
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.NEW) == FOrdStatus.NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.FILLED) == FOrdStatus.FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.NEW) == FOrdStatus.NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.ACCEPTED_FOR_BIDDING) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, '9', 0, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_CANCEL, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
     # fmt: on
 
 
@@ -394,20 +394,20 @@ def test_state_transition__pendingreplce__execution_report():
     # fmt: off
     # Executin report doesn't not have any effect of pending cancelled state
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.FILLED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.CANCELED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.STOPPED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.REJECTED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.SUSPENDED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.CALCULATED) is None
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.EXPIRED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PARTIALLY_FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.FILLED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.DONE_FOR_DAY) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CANCELED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_CANCEL) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.STOPPED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.REJECTED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.SUSPENDED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_NEW) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.CALCULATED) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.EXPIRED) is None
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.ACCEPTED_FOR_BIDDING) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.TRADE, FOrdStatus.PENDING_REPLACE) is None
     # fmt: on
 
 
@@ -415,14 +415,14 @@ def test_state_transition__pendingreplce__execution_report_exectype_replace():
     # fmt: off
     # Executin report doesn't not have any effect of pending cancelled state
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.NEW) == FOrdStatus.NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.FILLED) == FOrdStatus.FILLED
-    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.DONE_FOR_DAY) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.PENDING_CANCEL) 
-    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.STOPPED) 
-    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.REJECTED) 
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.REPLACED, FOrdStatus.NEW) == FOrdStatus.NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.REPLACED, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.REPLACED, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.DONE_FOR_DAY)
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.EXECUTIONREPORT, FExecType.REPLACED, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.PENDING_CANCEL)
+    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.STOPPED)
+    assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.REJECTED)
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.SUSPENDED) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.PENDING_NEW) 
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '8', FExecType.REPLACED, FOrdStatus.CALCULATED) 
@@ -436,20 +436,20 @@ def test_state_transition__pendingreplce__ord_reject():
     # fmt: off
     # But cancel reject request does!
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.CREATED) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.NEW) == FOrdStatus.NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.FILLED) == FOrdStatus.FILLED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.NEW) == FOrdStatus.NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PARTIALLY_FILLED) == FOrdStatus.PARTIALLY_FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.FILLED) == FOrdStatus.FILLED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.DONE_FOR_DAY) == FOrdStatus.DONE_FOR_DAY
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.CANCELED) == FOrdStatus.CANCELED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_CANCEL) == FOrdStatus.PENDING_CANCEL
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.STOPPED) == FOrdStatus.STOPPED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.REJECTED) == FOrdStatus.REJECTED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.SUSPENDED) == FOrdStatus.SUSPENDED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_NEW) == FOrdStatus.PENDING_NEW
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.CALCULATED) == FOrdStatus.CALCULATED
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.EXPIRED) == FOrdStatus.EXPIRED
     assert pytest.raises(FIXError, FIXNewOrderSingle.change_status, FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.ACCEPTED_FOR_BIDDING) 
-    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, '9', 0, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
+    assert FIXNewOrderSingle.change_status(FOrdStatus.PENDING_REPLACE, FMsg.ORDERCANCELREJECT, FExecType.NEW, FOrdStatus.PENDING_REPLACE) == FOrdStatus.PENDING_REPLACE
     # fmt: on
 
 
@@ -465,7 +465,7 @@ def test_exec_sequence__vanilla_fill():
     )
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
     assert o.order_id is None
     assert not o.can_cancel()
     assert not o.can_replace()
@@ -478,7 +478,7 @@ def test_exec_sequence__vanilla_fill():
     assert o.process_execution_report(msg) == 1
     assert o.avg_px == 0
     assert o.order_id is not None
-    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={o.status}"
     assert not o.can_cancel()
     assert not o.can_replace()
     assert o.is_finished() == 0
@@ -487,7 +487,7 @@ def test_exec_sequence__vanilla_fill():
         o, o.clord_id, FExecType.NEW, FOrdStatus.NEW, cum_qty=0, leaves_qty=10
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.NEW, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 0
     assert o.leaves_qty == 10
@@ -507,7 +507,7 @@ def test_exec_sequence__vanilla_fill():
         avg_price=120,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={o.status}"
     assert o.avg_px == 120
     assert o.qty == 10
     assert o.cum_qty == 2
@@ -527,7 +527,7 @@ def test_exec_sequence__vanilla_fill():
         last_qty=1,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 3
     assert o.leaves_qty == 7
@@ -542,7 +542,7 @@ def test_exec_sequence__vanilla_fill():
         last_qty=7,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.FILLED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.FILLED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 10
     assert o.leaves_qty == 0
@@ -565,19 +565,19 @@ def test_exec_sequence__vanilla_fill_reject__pendingnew():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.REJECTED, FOrdStatus.REJECTED, cum_qty=0, leaves_qty=0
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.REJECTED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.REJECTED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 0
     assert o.leaves_qty == 00
@@ -600,19 +600,19 @@ def test_exec_sequence__vanilla_fill__reject_new():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.NEW, FOrdStatus.NEW, cum_qty=0, leaves_qty=10
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.NEW, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 0
     assert o.leaves_qty == 10
@@ -621,7 +621,7 @@ def test_exec_sequence__vanilla_fill__reject_new():
         o, o.clord_id, FExecType.REJECTED, FOrdStatus.REJECTED, cum_qty=0, leaves_qty=0
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.REJECTED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.REJECTED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 0
     assert o.leaves_qty == 00
@@ -640,19 +640,19 @@ def test_exec_sequence__vanilla_suspended():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PENDING_NEW, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.NEW, FOrdStatus.NEW, cum_qty=0, leaves_qty=10
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.NEW, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.NEW, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 0
     assert o.leaves_qty == 10
@@ -667,7 +667,7 @@ def test_exec_sequence__vanilla_suspended():
         last_qty=2,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 2
     assert o.leaves_qty == 8
@@ -681,7 +681,7 @@ def test_exec_sequence__vanilla_suspended():
         leaves_qty=0,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.SUSPENDED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.SUSPENDED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 2
     assert o.leaves_qty == 0
@@ -699,7 +699,7 @@ def test_exec_sequence__vanilla_suspended():
         leaves_qty=8,
     )
     assert o.process_execution_report(msg) == 1
-    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.PARTIALLY_FILLED, f"o.status={o.status}"
     assert o.qty == 10
     assert o.cum_qty == 2
     assert o.leaves_qty == 8
@@ -749,7 +749,7 @@ def test_cancel_req__zero_filled_order():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -795,7 +795,7 @@ def test_cancel_req__zero_filled_order__cancel_reject():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -839,7 +839,7 @@ def test_cancel_req__zero_filled_order__cancel_reject_after_pending():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -899,7 +899,7 @@ def test_cancel_req__part_filled_order__with_some_execution_between():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1010,7 +1010,7 @@ def test_cancel_req__order_filled_before_cancel_accepted_different_clord():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1116,7 +1116,7 @@ def test_cancel_req__not_acknoledged_order_by_gate():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     with pytest.raises(FIXError, match="order is not allowed for cancel"):
         cxl_req = o.cancel_req()
@@ -1141,7 +1141,7 @@ def test_cancel_req__multiple_requests_are_blocked():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1171,7 +1171,7 @@ def test_cancel_req__order_filled_before_cancel_accepted():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1308,7 +1308,7 @@ def test_replace_req__zero_filled__increased_qty():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1380,7 +1380,7 @@ def test_replace_req__part_filled__increased_qty_while_pending_replace_fractiona
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1502,7 +1502,7 @@ def test_replace_req__zero_filled__cxlrep_reject_when_new():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1546,7 +1546,7 @@ def test_replace_req__filled_order_rejected_after_filled():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1612,7 +1612,7 @@ def test_replace_req__filled_order_rejected__filled_increase_passed():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1722,7 +1722,7 @@ def test_replace_req__replace_price_only_but_rejected_because_fill():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1785,7 +1785,7 @@ def test_replace_req__decreased_qty():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1859,7 +1859,7 @@ def test_replace_req__decreased_qty_exact_match_to_fill():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1921,7 +1921,7 @@ def test_replace_req__decreased_qty__also_less_than_cum_qty():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -1978,7 +1978,7 @@ def test_exec_report_clord_mismatch():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, "unknown clord", FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW
@@ -2000,7 +2000,7 @@ def test_cancel_req__cancel_reject_invalid_transition():
 
     ft = FIXTester(FIX_SCHEMA)
     assert ft.order_register_single(o) == 1
-    assert o.status == FOrdStatus.CREATED, f"o.status={chr(o.status)}"
+    assert o.status == FOrdStatus.CREATED, f"o.status={o.status}"
 
     msg = ft.fix_exec_report_msg(
         o, o.clord_id, FExecType.PENDING_NEW, FOrdStatus.PENDING_NEW

--- a/tests/test_protocol_schema.py
+++ b/tests/test_protocol_schema.py
@@ -354,8 +354,8 @@ def test_schema_validation(fix_simple_xml):
     m = FIXMessage(FMsg.EXECUTIONREPORT, {FTag.OrderID: "1234"})
     schema.validate(m)
 
-    m = FIXMessage("1ASD")
-    with pytest.raises(FIXMessageError, match="msg_type=`1ASD` not in schema"):
+    m = FIXMessage("9")
+    with pytest.raises(FIXMessageError, match="msg_type=`9` not in schema"):
         schema.validate(m)
 
     m = FIXMessage(FMsg.EXECUTIONREPORT, {})

--- a/tests/test_protocol_schema.py
+++ b/tests/test_protocol_schema.py
@@ -1,5 +1,6 @@
 import os
 import xml.etree.ElementTree as ET
+from typing import cast
 from unittest.mock import patch
 
 import pytest
@@ -38,7 +39,7 @@ def test_schema_field():
     assert f.name == "Account"
     assert f.ftype == "STRING"
     assert f.values == {}
-    # no values in SchemaField any allowed
+    # no values in SchemaField are allowed
     assert f.validate_value("adslkajdlskj")
 
     f.values["test"] = "1"
@@ -61,7 +62,7 @@ def test_schema_field():
     assert f in fields
     assert fields[f] == 1
     assert fields[f2] == 2
-    assert fields["Account"] == 1
+    assert fields["Account"] == 1  # type: ignore
 
     # search by tag not supported
     assert "1" not in fields
@@ -78,10 +79,10 @@ def test_schema_set():
     assert hash(s) == hash("myset")
 
     with pytest.raises(ValueError, match="Unsupported field_or_set type, got"):
-        s.add("notsupported", False)
+        s.add("notsupported", False)  # type: ignore
 
     with pytest.raises(ValueError, match="tag property is not supported"):
-        s.tag
+        _ = s.tag
 
     assert f in s
     assert f2 in s
@@ -97,19 +98,19 @@ def test_schema_set():
     with pytest.raises(
         ValueError, match="SchemaSet expected to have group field with "
     ):
-        SchemaSet("NoOrders", field=fg)
+        SchemaGroup(fg, True)
 
     with pytest.raises(FIXMessageError, match="item looks like tag"):
         assert "1" in s
 
     with pytest.raises(FIXMessageError, match="item looks like tag"):
-        assert 1 in s
+        assert 1 in s  # type: ignore
 
     with pytest.raises(FIXMessageError, match="item looks like tag"):
-        s["1"]
+        _ = s["1"]
 
     with pytest.raises(FIXMessageError, match="item looks like tag"):
-        s[1]
+        _ = s[1]  # type: ignore
 
 
 def test_schema_set_included_components():
@@ -189,7 +190,6 @@ def test_xml_init(fix_simple_xml):
     c = schema._components["ContraGrp"]
     assert isinstance(c, SchemaComponent)
     assert c.name == "ContraGrp"
-    assert c.field is None
 
     # Check messages
     assert schema._messages
@@ -864,10 +864,10 @@ def test_schema_validation_group(fix_simple_xml):
     assert schema["453"].tag == "453"
     assert schema["NoPartyIDs"].tag == "453"
 
-    m = schema._messages_types[FMsg.EXECUTIONREPORT]
+    m = schema._messages_types[str(FMsg.EXECUTIONREPORT)]
 
     assert m.msg_type == FMsg.EXECUTIONREPORT
-    g = m["NoPartyIDs"]
+    g: SchemaGroup = cast(SchemaGroup, m["NoPartyIDs"])
     assert isinstance(g, SchemaGroup)
 
     with pytest.raises(
@@ -896,7 +896,7 @@ def test_schema_validation_group(fix_simple_xml):
         )
         g.validate_group(msg_g.get_group_list(FTag.NoPartyIDs))
 
-    g = m["NoContraBrokers"]
+    g = cast(SchemaGroup, m["NoContraBrokers"])
     with pytest.raises(
         FIXMessageError, match="missing required field SchemaField.*ContraTrader|"
     ):
@@ -910,7 +910,7 @@ def test_schema_validation_group(fix_simple_xml):
         )
         g.validate_group(msg_g.get_group_list(FTag.NoContraBrokers))
 
-    g = m["NoContraBrokers"]
+    g = cast(SchemaGroup, m["NoContraBrokers"])
     with pytest.raises(FIXMessageError, match="incorrect tag order"):
         msg_g = FIXMessage(
             FMsg.EXECUTIONREPORT,
@@ -926,7 +926,7 @@ def test_schema_validation_group(fix_simple_xml):
         )
         g.validate_group(msg_g.get_group_list(FTag.NoContraBrokers))
 
-    g = m["NoContraBrokers"]
+    g = cast(SchemaGroup, m["NoContraBrokers"])
     with pytest.raises(
         FIXMessageError,
         match="Commission|12 validation error .* could not convert string to float:",
@@ -948,9 +948,9 @@ def test_schema_validation_group(fix_simple_xml):
 
 def test_schema_validation_group_nested(fix_simple_xml):
     schema = FIXSchema(fix_simple_xml)
-    m = schema._messages_types[FMsg.EXECUTIONREPORT]
+    m = schema._messages_types[str(FMsg.EXECUTIONREPORT)]
 
-    g = m["NoContraBrokers"]
+    g: SchemaGroup = cast(SchemaGroup, m["NoContraBrokers"])
 
     with pytest.raises(
         FIXMessageError,
@@ -1007,13 +1007,14 @@ def test_schema_validation_header(fix_simple_xml):
     m = FIXMessage(FMsg.EXECUTIONREPORT, {FTag.OrderID: "1234"})
 
     codec = Codec(FIXProtocol44())
-    session = FIXSession("1", "TARG", "SEND")
+    session = FIXSession(1, "TARG", "SEND")
     session.next_num_in = 1
     session.next_num_out = 1
     enc_m = codec.encode(m, session)
 
     dec_m, _, _ = codec.decode(enc_m.encode(), silent=False)
 
+    assert dec_m is not None
     schema.validate(dec_m)
 
     del dec_m[FTag.MsgSeqNum]

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -5,25 +5,25 @@ from asyncfix.session import FIXSession
 
 
 def test_init():
-    s = FIXSession("1", "target", "sender")
-    assert s.key == "1"
+    s = FIXSession(1, "target", "sender")
+    assert s.key == 1
     assert s.target_comp_id == "target"
     assert s.sender_comp_id == "sender"
 
-    assert s.next_num_in is None
-    assert s.next_num_out is None
+    assert s.next_num_in == 0
+    assert s.next_num_out == 0
 
 
 def test_hash():
-    s = FIXSession("1", "target", "sender")
+    s = FIXSession(1, "target", "sender")
     assert hash(s) == hash((s.target_comp_id, s.sender_comp_id))
 
 
 def test_equality():
-    s1 = FIXSession("1", "target", "sender")
-    s2 = FIXSession("2", "target", "sender")
-    s3 = FIXSession("1", "target1", "sender")
-    s4 = FIXSession("1", "target", "sender2")
+    s1 = FIXSession(1, "target", "sender")
+    s2 = FIXSession(2, "target", "sender")
+    s3 = FIXSession(1, "target1", "sender")
+    s4 = FIXSession(1, "target", "sender2")
 
     assert s1 == s2
     assert s1 != s3
@@ -37,28 +37,28 @@ def test_equality():
 
 
 def test_repr():
-    s1 = FIXSession("1", "target", "sender")
+    s1 = FIXSession(1, "target", "sender")
     s1.next_num_out = 1
     s1.next_num_in = 1
     assert "FIXSession(key=1, target=target sender=sender InSN=1 OutSN=1)" == repr(s1)
 
 
 def test_validate_compid():
-    s1 = FIXSession("1", "target", "sender")
+    s1 = FIXSession(1, "target", "sender")
 
     assert s1.validate_comp_ids("target", "sender")
     assert not s1.validate_comp_ids("sender", "target")
 
 
 def test_allocate_next_num_out():
-    s1 = FIXSession("1", "target", "sender")
+    s1 = FIXSession(1, "target", "sender")
     s1.next_num_out = 1
     assert s1.allocate_next_num_out() == "1"
     assert s1.next_num_out == 2
 
 
 def test_set_next_num_in():
-    s1 = FIXSession("1", "target", "sender")
+    s1 = FIXSession(1, "target", "sender")
 
     s1.next_num_in = 10
 


### PR DESCRIPTION
Hi @alexveden,

continued on the journey regarding small fixes, mostly due to type hinting, especially the common issues with optional attributes. It is a lot of small changes which came mostly from an internal project I was working on where mypy was making my life difficult.

Some of the bigger changes:
- schema.py: move `field` into `SchemaGroup`
- fix_tester.py: `FIXConnTester` which has a connection, compared to `FIXTester` which does not
- moved the transitions from order_single.py into a new file, transition.py

Let me know what you think.
Thanks,
Tibor

